### PR TITLE
Red Cog Approval: coffeetime

### DIFF
--- a/coffeetime/coffeetime.py
+++ b/coffeetime/coffeetime.py
@@ -62,7 +62,7 @@ class Coffeetime(commands.Cog):
 
     # Bot Commands
 
-    @commands.command()
+    @commands.hybrid_command(name="time")
     @commands.has_permissions(embed_links=True)
     async def time(self, ctx, user: discord.Member = None):
         """Shows the current time for the specified user."""
@@ -101,15 +101,15 @@ class Coffeetime(commands.Cog):
                     timemsg2 = f" **{time_amt}{position_text}**"
                 else:
                   if not usertime:
-                      timemsg4 = f"You haven't set your timezone yet 👀 Do `{ctx.prefix}timeset` to share your timezone!"
+                      timemsg4 = f"You haven't set your timezone yet 👀 Do `{ctx.prefix}settime` to share your timezone!"
 
             await ctx.send(timemsg1+timemsg2+timemsg3)
             if timemsg4:
               await ctx.send(timemsg4)
         else:
-            await ctx.send(f"{user.display_name} hasn't set a timezone yet. Set one by typing `{ctx.prefix}timeset` !")
+            await ctx.send(f"{user.display_name} hasn't set a timezone yet. Set one by typing `{ctx.prefix}settime` !")
 
-    @commands.command()
+    @commands.hybrid_command(name="settime", aliases=["timeset"])
     @commands.has_permissions(embed_links=True)
     async def timeset(self, ctx, *, city_name_here):
         """
@@ -125,7 +125,7 @@ class Coffeetime(commands.Cog):
             await self.config.user(ctx.author).usertime.set(tz_resp[0][0])
             await ctx.send(f"Successfully set your timezone to **{tz_resp[0][0]}**!")
 
-    @commands.command()
+    @commands.hybrid_command(name="timein")
     @commands.has_permissions(embed_links=True)
     async def timein(self, ctx, *, city_name: str):
         """Gets the time in a timezone.
@@ -142,7 +142,7 @@ class Coffeetime(commands.Cog):
             await ctx.send(">>> "+time.strftime(fmt)+f", {tz_resp[0][0]}*")
 
     @commands.guild_only()
-    @commands.group()
+    @commands.hybrid_group(name="timetools")
     @commands.has_permissions(embed_links=True)
     async def timetools(self, ctx):
         """
@@ -174,10 +174,10 @@ class Coffeetime(commands.Cog):
                     "Use the two-character code under the `Alpha-2 code` column."
                 )
 
-    @timetools.command()
+    @timetools.command(name="set")
     @commands.is_owner()
     @commands.has_permissions(embed_links=True)
-    async def set(self, ctx, user: discord.User, *, timezone_name=None):
+    async def timetools_set(self, ctx, user: discord.User, *, timezone_name=None):
         """
         Allows the bot owner to edit users' timezones.
         Use a user id for the user if they are not present in your server.

--- a/coffeetime/coffeetime.py
+++ b/coffeetime/coffeetime.py
@@ -63,6 +63,7 @@ class Coffeetime(commands.Cog):
     # Bot Commands
 
     @commands.command()
+    @commands.has_permissions(embed_links=True)
     async def time(self, ctx, user: discord.Member = None):
         """Shows the current time for the specified user."""
         if not user:
@@ -109,6 +110,7 @@ class Coffeetime(commands.Cog):
             await ctx.send(f"{user.display_name} hasn't set a timezone yet. Set one by typing `{ctx.prefix}timeset` !")
 
     @commands.command()
+    @commands.has_permissions(embed_links=True)
     async def timeset(self, ctx, *, city_name_here):
         """
         Sets your timezone.
@@ -124,6 +126,7 @@ class Coffeetime(commands.Cog):
             await ctx.send(f"Successfully set your timezone to **{tz_resp[0][0]}**!")
 
     @commands.command()
+    @commands.has_permissions(embed_links=True)
     async def timein(self, ctx, *, city_name: str):
         """Gets the time in a timezone.
 
@@ -140,6 +143,7 @@ class Coffeetime(commands.Cog):
 
     @commands.guild_only()
     @commands.group()
+    @commands.has_permissions(embed_links=True)
     async def timetools(self, ctx):
         """
         Checks the time.
@@ -149,6 +153,7 @@ class Coffeetime(commands.Cog):
         pass
 
     @timetools.command()
+    @commands.has_permissions(embed_links=True)
     async def iso(self, ctx, *, iso_code=None):
         """Looks up ISO3166 country codes and gives you a supported timezone."""
         if iso_code is None:
@@ -171,6 +176,7 @@ class Coffeetime(commands.Cog):
 
     @timetools.command()
     @commands.is_owner()
+    @commands.has_permissions(embed_links=True)
     async def set(self, ctx, user: discord.User, *, timezone_name=None):
         """
         Allows the bot owner to edit users' timezones.
@@ -192,6 +198,7 @@ class Coffeetime(commands.Cog):
                 await ctx.send(f"Successfully set {user.name}'s timezone to **{tz_resp[0][0]}**.")
 
     @timetools.command()
+    @commands.has_permissions(embed_links=True)
     async def user(self, ctx, user: discord.Member = None):
         """Shows the current time for the specified user."""
         if not user:
@@ -209,6 +216,7 @@ class Coffeetime(commands.Cog):
                 await ctx.send("That user hasn't set their timezone.")
 
     @timetools.command()
+    @commands.has_permissions(embed_links=True)
     async def compare(self, ctx, user: discord.Member = None):
         """Compare your saved timezone with another user's timezone."""
         if not user:


### PR DESCRIPTION
#45

CoffeeTime

- [x]     :memo: Commands do not check if the bot has embed_links permissions where needed.
- [DELAY]     [p]timetools user, [p]timetools compare, and [p]time all seem to do a very similar thing.
  - **Response:**
  The main `time` command adapts the formatting slightly. `timetools user` and `compare` are legacy commands from an upstream fork. These are maintained for drop-in compatibility, but may be cleaned in a future release.

General

- [see #45]     Consider using TitleCase instead of Titlecase casing for your class names to maintain consistency with how users expect to get [p]help for 3rd party cogs.
- [x]     Your cogs don’t have internal consistency between [p]<cog>set (ie [p]barset) and [p]set<cog> (ie [p]setwebsearch).
  - `timeset` -> `settime` @ https://github.com/coffeebank/coffee-cogs/pull/50/commits/152de662bda369fc2eb1918f3f113a231def9bb6