### PR TITLE
Red Cog Approval: kodict

### DIFF
--- a/kodict/kodict.py
+++ b/kodict/kodict.py
@@ -26,7 +26,7 @@ class Kodict(commands.Cog):
 
     @commands.hybrid_command(name="kodict", aliases=["krdict"])
     @app_commands.describe(text="Search Korean dictionary. Search using Korean (Hangul/Hanja) and English.")
-    @commands.has_permissions(embed_links=True)
+    @commands.bot_has_permissions(embed_links=True)
     async def kodict(self, ctx, *, text: str):
         """Search Korean dictionary
         
@@ -43,7 +43,7 @@ class Kodict(commands.Cog):
 
     @commands.hybrid_command(name="kosearch", aliases=["krsearch"])
     @app_commands.describe(text="Search Korean vocabulary and translation websites")
-    @commands.has_permissions(embed_links=True)
+    @commands.bot_has_permissions(embed_links=True)
     async def kosearch(self, ctx, *, text):
         """Search Korean vocabulary and translation websites"""
         fallback_embed = await embed_fallback(text)

--- a/kodict/kodict.py
+++ b/kodict/kodict.py
@@ -26,6 +26,7 @@ class Kodict(commands.Cog):
 
     @commands.hybrid_command(name="kodict", aliases=["krdict"])
     @app_commands.describe(text="Search Korean dictionary. Search using Korean (Hangul/Hanja) and English.")
+    @commands.has_permissions(embed_links=True)
     async def kodict(self, ctx, *, text: str):
         """Search Korean dictionary
         
@@ -42,6 +43,7 @@ class Kodict(commands.Cog):
 
     @commands.hybrid_command(name="kosearch", aliases=["krsearch"])
     @app_commands.describe(text="Search Korean vocabulary and translation websites")
+    @commands.has_permissions(embed_links=True)
     async def kosearch(self, ctx, *, text):
         """Search Korean vocabulary and translation websites"""
         fallback_embed = await embed_fallback(text)


### PR DESCRIPTION
#45

KoDict

- [x]     It is unclear why the coffee_redbot path exists as a clone of Red, unless it is being used in the public bot version of this cog and you didn’t want to change the imports between versions. I would suggest using the normal Red imports in the cog if possible.
  - **Response:**
  The custom `coffee_redbot` version of SimpleMenu adds a `replace()` command. This is necessary, since API calls may take longer than 3 seconds (required by slash commands), so a "Searching" embed is sent, and later replaced by editing the message using a given message ID.
- [x]     :memo: It doesn’t appear that lxml or krdict.py are being used, despite being in the requirements.
  - **Response:**
    - `krdict.py` is used to fetch and parse API results from the National Institute of Korean Language's Korean-English Learners' Dictionary (한국어기초사전), and works with or without an API key.
      - `krdict.py` depends on `lxml`, to parse web results without an API key.
      - `krdict.py@git...` is a custom forked version of `krdict.py` that has been migrated to async.
    - `kodict_core` depends on `krdict.py@git...`, and is an independent CLI-style Python package that contains most of the formatting logic and integrations (ex. DeepL).
    - `kodict` (Red cog) is a Discord bot wrapper for `kodict_core`.
    - Without requiring the downstream dependencies, errors for missing packages are returned.
- [x]     The install_msg points to setup instructions in the docs that only list krdict as a valid [p]set api name, but deepl is not listed. Additionally, there are no instructions as to how to get tokens from the API services.
  - **Response:**
  Added setup instructions for Krdict and DeepL API at [https://coffeebank.github.io/coffee-cogs/kodict/](https://coffeebank.github.io/coffee-cogs/kodict/)
- [x]     :memo: The cog silently edits the Searching text to an empty message in [p]kodict if the bot does not have embed_links permissions.
  - **Response:**
  Fixed by adding `bot_has_permissions` `embed_links`.
- [x]     :memo: [p]kosearch does not check if the bot has embed_links permissions.
  - **Response:**
  Fixed by adding `bot_has_permissions` `embed_links`.

General

- [see #45]     Consider using TitleCase instead of Titlecase casing for your class names to maintain consistency with how users expect to get [p]help for 3rd party cogs.
- [see #45]     Some cogs have aiohttp and asyncio in their requirements. Those libraries are already requirements of Red, so listing them is not necessary.
- [see #45]     Despite some cogs including it, permissions is not a valid info.json key, and including it will not resolve the need to add proper permissions checking to commands.
- [⏩]     Consider checking the response.status in your aiohttp requests in case the URL requested goes offline or has an error.
  - **Response:**
  Update will be planned for `kodict_core`.
