### PR TITLE
Red Cog Approval: jadict

### DIFF
--- a/jadict/jadict.py
+++ b/jadict/jadict.py
@@ -62,6 +62,7 @@ class Jadict(commands.Cog):
 
     @commands.hybrid_command(name="jadict", aliases=["jpdict", "jisho", "jishosearch"])
     @app_commands.describe(text="Search Japanese dictionary. By default, searches using Japanese and Romaji. When searching in English, please use  \"quotes\"")
+    @commands.bot_has_permissions(embed_links=True)
     async def jadict(self, ctx, *, text):
         """Search Japanese dictionary
 
@@ -86,6 +87,7 @@ class Jadict(commands.Cog):
 
     @commands.hybrid_command(name="jasearch", aliases=["jpsearch"])
     @app_commands.describe(text="Search Japanese vocabulary and translation websites")
+    @commands.bot_has_permissions(embed_links=True)
     async def jasearch(self, ctx, *, text):
         """Search Japanese vocabulary and translation websites"""
         fallback_embed = await self.fallbackEmbed(ctx, text)

--- a/jadict/jadict_utils.py
+++ b/jadict/jadict_utils.py
@@ -107,6 +107,9 @@ async def fetchJisho(text):
 async def makeJsonRequest(url):
     async with aiohttp.ClientSession() as session:
         async with session.get(url) as resp:
+            if resp.status != 200:
+                logger.error(f"Failed to fetch {url}. Status code: {resp.status}")
+                return None
             reqdata = await resp.json()
             return reqdata
 

--- a/jadict/jadict_utils.py
+++ b/jadict/jadict_utils.py
@@ -208,7 +208,7 @@ def to_romaji(text: str):
                     final_str += "."
             else:
                 final_str += str(kana_dict[str(text_arr[idx])])
-        except:
+        except Exception:
             # Skip over invalid character
             continue
         pointer += 1

--- a/jadict/jadict_utils.py
+++ b/jadict/jadict_utils.py
@@ -101,7 +101,7 @@ async def fetchJisho(text):
             return jishoJson
         else:
             return False
-    except:
+    except Exception:
         return None
 
 async def makeJsonRequest(url):


### PR DESCRIPTION
#45

Jadict

- [x]     :memo: [p]jadict and [p]jasearch do not check if the bot has embed_links permissions.

General

- [see #45]     Consider using TitleCase instead of Titlecase casing for your class names to maintain consistency with how users expect to get [p]help for 3rd party cogs.
- [see #45]     Some cogs have aiohttp and asyncio in their requirements. Those libraries are already requirements of Red, so listing them is not necessary.
- [see #45]     Despite some cogs including it, permissions is not a valid info.json key, and including it will not resolve the need to add proper permissions checking to commands.
- [x]     You have bare except blocks in a few places. Consider at least replacing them with except Exception, to avoid catching standard control errors like the one generated by CTRL+Cing. Ideally, identify the error you actually intend to catch and use that instead (generally discord.HTTPException is a good bet for Discord API calls).
- [x]     Consider checking the response.status in your aiohttp requests in case the URL requested goes offline or has an error.
