### PR TITLE
Red Cog Approval: msgmover

### DIFF
--- a/msgmover/info.json
+++ b/msgmover/info.json
@@ -3,7 +3,7 @@
   "install_msg" : "Thanks for installing, I hope you enjoy :) To stay up to date with breaking changes, you might want to join my Support Discord. To find documentation, Discord, and more, drop by my site at https://coffeebank.github.io/coffee-cogs/msgmover/",
   "name" : "msgmover",
   "short" : "Move messages across channels and servers",
-  "requirements" : ["aiohttp", "requests"],
+  "requirements" : [],
   "description" : "Make moving messages between channels/servers easy and integrated, using webhooks.\n\nmsgcopy: Copy messages from one channel to another. Move whole conversations, or merge channels easily with re-uploaded attachments, bot messages, and usernames/profiles replicated in full. Includes timestamp spacers.\n\nmsgrelay: Relay messages from one channel to another channel/server. Supports usernames/profile pics, replies, attachments (files/images/video), and embeds (bot command replies). Supports edited/deleted messages. Supports forwarding to multiple webhooks/channels.\n\nUpdated for Red 3.5",
   "permissions" : [],
   "end_user_data_statement" : "This cog does not store any End User Data.",

--- a/msgmover/info.json
+++ b/msgmover/info.json
@@ -1,6 +1,6 @@
 {
   "author" : ["coffeebank"],
-  "install_msg" : "Thanks for installing, I hope you enjoy :) To stay up to date with breaking changes, you might want to join my Support Discord. To find documentation, Discord, and more, drop by my site at https://coffeebank.github.io/coffee-cogs/msgmover/",
+  "install_msg" : "Thanks for installing, I hope you enjoy :) To stay up to date with breaking changes, you might want to join my Support Discord. To find documentation, Discord, and more, drop by my site at https://coffeebank.github.io/coffee-cogs/msgmover/\n\nMsgmover comes with two key features, both of which use webhooks to move messages from one place to another with a close-to-native feel:\n\n**`[p]msgcopy`** - Copies a set # of messages from one channel to another *(single-use)*\n- *Requires users with **Manage Messages** permissions*\n\n**`[p]msgrelay`** - Forward new messages to other channels/servers *(continuous)*\n- *Requires server admins with **Administrator** permissions*\n\nNeed help? [Reach us in our Support Discord >](https://coffeebank.github.io/discord)\n\nTo see this message again, type **`[p]help Msgmover`**",
   "name" : "msgmover",
   "short" : "Move messages across channels and servers",
   "requirements" : [],

--- a/msgmover/msgmover.py
+++ b/msgmover/msgmover.py
@@ -17,10 +17,15 @@ logger = logging.getLogger(__name__)
 class Msgmover(commands.Cog):
     """Move messages around, cross-channels, cross-server!
     
-    Run `[p]msgmover` to see more details!
+    Msgmover comes with two key features, both of which use webhooks to move messages from one place to another with a close-to-native feel:
 
-    msgcopy: Copy a set # of past messages to another channel/server
-    msgrelay: Forward all of a channel's messages to another channel/server
+    **`[p]msgcopy`** - Copies a set # of messages from one channel to another *(single-use)*
+    - *Requires users with **Manage Messages** permissions*
+
+    **`[p]msgrelay`** - Forward new messages to other channels/servers *(continuous)*
+    - *Requires server admins with **Administrator** permissions*
+
+    Need help? [Reach us in our Support Discord >](https://coffeebank.github.io/discord)
     """
 
     def __init__(self, bot):
@@ -50,30 +55,10 @@ class Msgmover(commands.Cog):
         pass
 
 
-    # Bot Commands
-
-    @commands.group()
-    @commands.has_permissions(manage_messages=True)
-    async def msgmover(self, ctx: commands.Context):
-        """Hi! Thanks for installing msgmover!
-
-        Msgmover comes with two key features, both of which use webhooks to move messages from one place to another with a close-to-native feel:
-
-        **`[p]msgcopy`** - Copies a set # of messages from one channel to another *(single-use)*
-        - *Requires users with **Manage Messages** permissions*
-
-        **`[p]msgrelay`** - Forward messages to other channels/servers *(continuous)*
-        - *Requires server admins with **Administrator** permissions*
-
-        Need help? [Reach us in our Support Discord >](https://coffeebank.github.io/discord)
-        """
-        if not ctx.invoked_subcommand:
-            pass
-
 
     # msgcopy
 
-    @commands.command(aliases=["msgmove"])
+    @commands.command(aliases=["msgmove", "msgmover"])
     @commands.has_permissions(manage_messages=True)
     @commands.bot_has_permissions(add_reactions=True, read_message_history=True)
     async def msgcopy(self, ctx, fromChannel: discord.TextChannel, toChannel: typing.Union[discord.TextChannel, str], maxMessages:int, skipMessages:int=0):
@@ -85,7 +70,8 @@ class Msgmover(commands.Cog):
         
         Retrieving more than 10 messages will result in Discord ratelimit throttling, so please be patient.
         
-        *Errors? Please [help us by reporting them in our Support Discord >](https://coffeebank.github.io/discord)*"""
+        - *Errors? Please [help us by reporting them in our Support Discord >](https://coffeebank.github.io/discord)*
+        - *See all commands:* **`[p]help Msgmover`**"""
 
         # Error catching
         toWebhook = await relayCheckInput(self, ctx, toChannel)
@@ -149,9 +135,11 @@ class Msgmover(commands.Cog):
     @commands.has_permissions(administrator=True)
     @commands.bot_has_permissions(add_reactions=True, embed_links=True)
     async def msgrelay(self, ctx: commands.Context):
-        """Create message relays
+        """Forward new messages to other channels/servers
 
-        Forward new messages to another server via a webhook - as if you created a portal between the two chats.
+        Create message relays - as if a portal connects the two chats.
+
+        Have two-way conversations across 2+ servers at once!
         
         *[Join the Support Discord for announcements and more info](https://coffeebank.github.io/discord)*"""
         if not ctx.invoked_subcommand:

--- a/msgmover/msgmover.py
+++ b/msgmover/msgmover.py
@@ -235,7 +235,7 @@ class Msgmover(commands.Cog):
         # Add react on complete
         try:
             await ctx.message.add_reaction("✅")
-        except discord.errors.NotFound:
+        except discord.NotFound:
             await ctx.send("Done!")
 
     @commands.group()
@@ -381,7 +381,7 @@ class Msgmover(commands.Cog):
                     await asyncio.sleep(relayTimer)
                     try:
                         endMsg = await message.channel.fetch_message(message.id)
-                    except discord.errors.NotFound:
+                    except discord.NotFound:
                         for wf in hookData:
                             configJson = self.relayGetData(wh)
                             webhook = SyncWebhook.from_url(wf["toWebhook"])

--- a/msgmover/msgmover.py
+++ b/msgmover/msgmover.py
@@ -143,17 +143,25 @@ class Msgmover(commands.Cog):
         
         *[Join the Support Discord for announcements and more info](https://coffeebank.github.io/discord)*"""
         if not ctx.invoked_subcommand:
-            # Message Relays
-            msgrelayStoreV2 = await self.config.guild(ctx.guild).msgrelayStoreV2()
-            relayList = ""
-            for relayId in msgrelayStoreV2:
-                relayList += f"**<#{relayId}>**\n{str(msgrelayStoreV2[relayId])}\n\n"
-            eg = discord.Embed(color=(await ctx.embed_colour()), title="Message Relays in this Server", description=str(relayList)[:4090])
+            pass
+
+    @msgrelay.command(name="settings")
+    @commands.has_permissions(administrator=True)
+    @commands.bot_has_permissions(embed_links=True)
+    async def mmmrsettings(self, ctx):
+        """See relay settings (⚠️ Sensitive info)
+        """
+        # Message Relays
+        msgrelayStoreV2 = await self.config.guild(ctx.guild).msgrelayStoreV2()
+        relayList = ""
+        for relayId in msgrelayStoreV2:
+            relayList = f"**<#{relayId}>**\n{str(msgrelayStoreV2[relayId])}\n\n"
+            eg = discord.Embed(color=(await ctx.embed_colour()), description=str(relayList)[:4090])
             await ctx.send(embed=eg)
-            # Relay settings
-            es = discord.Embed(color=(await ctx.embed_colour()), title="Message Relay Settings in this Server")
-            es.add_field(name="Relay Timer", value=await self.config.guild(ctx.guild).relayTimer(), inline=True)
-            await ctx.send(embed=es)
+        # Relay settings
+        es = discord.Embed(color=(await ctx.embed_colour()), title="Message Relay Settings in this Server")
+        es.add_field(name="Relay Timer", value=await self.config.guild(ctx.guild).relayTimer(), inline=True)
+        await ctx.send(embed=es)
 
     @msgrelay.command(name="add")
     @commands.bot_has_permissions(add_reactions=True)

--- a/msgmover/msgmover.py
+++ b/msgmover/msgmover.py
@@ -85,8 +85,7 @@ class Msgmover(commands.Cog):
         
         Retrieving more than 10 messages will result in Discord ratelimit throttling, so please be patient.
         
-        *Errors? Please [help us by reporting them in our Support Discord >](https://coffeebank.github.io/discord)*
-        """
+        *Errors? Please [help us by reporting them in our Support Discord >](https://coffeebank.github.io/discord)*"""
 
         # Error catching
         toWebhook = await relayCheckInput(self, ctx, toChannel)
@@ -154,8 +153,6 @@ class Msgmover(commands.Cog):
 
         Forward new messages to another server via a webhook - as if you created a portal between the two chats.
         
-        (Also works with Discord-webhook-compatible bridges for other chat apps.)
-
         *[Join the Support Discord for announcements and more info](https://coffeebank.github.io/discord)*"""
         if not ctx.invoked_subcommand:
             # Message Relays

--- a/msgmover/msgmover.py
+++ b/msgmover/msgmover.py
@@ -1,6 +1,5 @@
 import asyncio
 import aiohttp
-import json
 import typing
 
 from redbot.core import Config, commands, checks
@@ -75,6 +74,8 @@ class Msgmover(commands.Cog):
             pass
 
 
+    # msgcopy
+
     @commands.command(aliases=["msgmove"])
     @commands.has_permissions(manage_messages=True)
     @commands.bot_has_permissions(add_reactions=True, read_message_history=True)
@@ -142,6 +143,8 @@ class Msgmover(commands.Cog):
             await ctx.send("Done!")
 
 
+    # msgrelay
+
     @commands.group()
     @commands.has_permissions(administrator=True)
     @commands.bot_has_permissions(add_reactions=True, embed_links=True)
@@ -167,6 +170,7 @@ class Msgmover(commands.Cog):
             await ctx.send(embed=es)
 
     @msgrelay.command(name="add")
+    @commands.bot_has_permissions(add_reactions=True)
     async def mmmradd(self, ctx, fromChannel: discord.TextChannel, toChannel: typing.Union[discord.TextChannel, str]):
         """Create a message relay
         
@@ -187,17 +191,25 @@ class Msgmover(commands.Cog):
         # Test
         try:
             await fromChannel.send("**Channels are now linked!**\nThis is a sample message.")
-        except:
+        except Exception as err:
+            logger.error(err)
             return await ctx.send("Setup was successfully completed, but some permissions may be missing.")
         await ctx.message.add_reaction("✅")
 
     @msgrelay.command(name="edit")
-    async def mmmredit(self, ctx, fromChannel: discord.TextChannel, itemToEdit: int, toChannel):
+    @commands.bot_has_permissions(add_reactions=True)
+    async def mmmredit(self, ctx, fromChannel: discord.TextChannel, itemToEdit: int, toChannel: typing.Union[discord.TextChannel, str]):
         """Edit a message relay
+        
+        fromChannel: the originating #channel
+        itemToEdit: put 1, 2, ... for which one you want to delete. (check `[p]msgrelay settings` for list of relays from each channel)
         
         Currently only supports webhook urls. [How to create webhooks.](https://support.discord.com/hc/article_attachments/1500000463501/Screen_Shot_2020-12-15_at_4.41.53_PM.png)
         *[Help us develop support for #channels >](https://coffeebank.github.io/discord)*"""
+
         # Error catching
+        if itemToEdit <= 0:
+            return await ctx.send("Error: If there's only one relay in the channel, please use 1 for itemToEdit.")
         relayResp = await relayCheckInput(self, ctx, toChannel)
         if relayResp == False:
             return
@@ -215,16 +227,18 @@ class Msgmover(commands.Cog):
         # Test
         try:
             await fromChannel.send("**Channels are now linked!**\nThis is a sample message.")
-        except:
+        except Exception as err:
+            logger.error(err)
             return await ctx.send("Setup was successfully completed, but some permissions may be missing.")
         await ctx.message.add_reaction("✅")
 
     @msgrelay.command(name="delete", aliases=["remove"])
+    @commands.bot_has_permissions(add_reactions=True)
     async def mmmrdelete(self, ctx, fromChannel: discord.TextChannel, itemToDelete: int):
         """Delete a message relay
         
         fromChannel: the originating #channel
-        itemToDelete: put 1, 2, ... for which one you want to delete.
+        itemToDelete: put 1, 2, ... for which one you want to delete. (check `[p]msgrelay settings` for list of relays from each channel)
         
         To delete all relays for a fromChannel, set itemToDelete to 0 (zero)."""
         result = await relayRemoveChannel(self, ctx, fromChannel, itemToDelete)
@@ -233,6 +247,7 @@ class Msgmover(commands.Cog):
         await ctx.message.add_reaction("✅")
 
     @msgrelay.command(name="settimer")
+    @commands.bot_has_permissions(add_reactions=True)
     async def mmmrsettimer(self, ctx, seconds: int):
         """Seconds after the relay checks for edited/deleted messages
         
@@ -241,6 +256,7 @@ class Msgmover(commands.Cog):
         await ctx.message.add_reaction("✅")
 
     @commands.command()
+    @commands.bot_has_permissions(add_reactions=True)
     async def msgcount(self, ctx):
         """Find how many messages it has been after a message
         

--- a/msgmover/msgmover.py
+++ b/msgmover/msgmover.py
@@ -483,7 +483,7 @@ class Msgmover(commands.Cog):
         # Add attachment if exists
         msgAttach = None
         if message.attachments:
-            attachMaxSize = 25000000 # 25MB, prev. 8MB
+            attachMaxSize = 10000000 # 10MB, prev. 25MB, prev. 8MB
             attachSuccess = False
             if json["attachsAsUrl"] == False:
                 try:

--- a/msgmover/msgmover.py
+++ b/msgmover/msgmover.py
@@ -58,7 +58,7 @@ class Msgmover(commands.Cog):
 
     # msgcopy
 
-    @commands.command(aliases=["msgmove", "msgmover"])
+    @commands.command(name="msgcopy", aliases=["msgmove", "msgmover"])
     @commands.has_permissions(manage_messages=True)
     @commands.bot_has_permissions(add_reactions=True, read_message_history=True)
     async def msgcopy(self, ctx, fromChannel: discord.TextChannel, toChannel: typing.Union[discord.TextChannel, str], maxMessages:int, skipMessages:int=0):
@@ -128,10 +128,24 @@ class Msgmover(commands.Cog):
         finally:
             await session.close()
 
+    @commands.command(name="msgcount")
+    @commands.bot_has_permissions(add_reactions=True)
+    async def msgcount(self, ctx):
+        """Find how many messages it has been after a message
+        
+        Reply to a message to use this command."""
+        if ctx.message.reference:
+            await ctx.message.add_reaction("⏳")
+            messages = [message async for message in ctx.channel.history(limit=None, after=ctx.message.reference.resolved)]
+            await ctx.message.add_reaction("✅")
+            return await ctx.send(str(len(messages))+" + 2 (your bot command and this message)")
+        else:
+            return await ctx.send("Please reply to a message to use this command!")
+
 
     # msgrelay
 
-    @commands.group()
+    @commands.group(name="msgrelay")
     @commands.has_permissions(administrator=True)
     @commands.bot_has_permissions(add_reactions=True, embed_links=True)
     async def msgrelay(self, ctx: commands.Context):
@@ -249,19 +263,6 @@ class Msgmover(commands.Cog):
         await self.config.guild(ctx.guild).relayTimer.set(seconds)
         await ctx.message.add_reaction("✅")
 
-    @commands.command()
-    @commands.bot_has_permissions(add_reactions=True)
-    async def msgcount(self, ctx):
-        """Find how many messages it has been after a message
-        
-        Reply to a message to use this command."""
-        if ctx.message.reference:
-            await ctx.message.add_reaction("⏳")
-            messages = [message async for message in ctx.channel.history(limit=None, after=ctx.message.reference.resolved)]
-            await ctx.message.add_reaction("✅")
-            return await ctx.send(str(len(messages))+" + 2 (your bot command and this message)")
-        else:
-            return await ctx.send("Please reply to a message to use this command!")
 
 
     # Listeners

--- a/msgmover/utils.py
+++ b/msgmover/utils.py
@@ -22,19 +22,19 @@ async def msgFormatter(self, webhook, message, json, editMsgId=None, deleteMsgId
     # Delete the message if it's delete
     if deleteMsgId is not None:
         try:
-            return webhook.delete_message(deleteMsgId)
+            return await webhook.delete_message(deleteMsgId)
         except:
             return False
 
     # Edit the message if it's edit
     if editMsgId is not None:
         try:
-            return webhook.edit_message(
+            return await webhook.edit_message(
                 message_id=editMsgId,
                 content=message.clean_content
             )
         except discord.HTTPException:
-            return webhook.edit_message(
+            return await webhook.edit_message(
                 message_id=editMsgId,
                 content="**Discord:** Unsupported content\n"+str(message.clean_content)
             )
@@ -83,7 +83,7 @@ async def msgFormatter(self, webhook, message, json, editMsgId=None, deleteMsgId
         else:
             replyEmbed.set_author(name=replyTitle, url=refUrl)
         # Send this before the original message so that the embed appears above the message in chat
-        webhook.send(
+        await webhook.send(
             username=userProfilesName,
             avatar_url=userProfilesAvatar,
             embed=replyEmbed
@@ -114,14 +114,14 @@ async def msgFormatter(self, webhook, message, json, editMsgId=None, deleteMsgId
                 for mm in message.attachments:
                     try:
                         assert mm.size < attachMaxSize
-                        webhook.send(
+                        await webhook.send(
                             username=userProfilesName,
                             avatar_url=userProfilesAvatar,
                             files=[await mm.to_file()],
                             wait=True
                         )
                     except AssertionError:
-                        webhook.send(
+                        await webhook.send(
                             content="**Discord:** File too large\n"+str(mm.url),
                             username=userProfilesName,
                             avatar_url=userProfilesAvatar,
@@ -165,7 +165,7 @@ async def msgFormatter(self, webhook, message, json, editMsgId=None, deleteMsgId
           "files": msgAttach,
           "wait": True
         }
-        whMsg = webhook.send(
+        whMsg = await webhook.send(
             **{k: v for k, v in whMsgArgs.items() if v is not None}
         )
     except discord.HTTPException:
@@ -182,7 +182,7 @@ async def msgFormatter(self, webhook, message, json, editMsgId=None, deleteMsgId
                   "files": msgAttach,
                   "wait": True
                 }
-                whMsg = webhook.send(
+                whMsg = await webhook.send(
                     **{k: v for k, v in whMsgArgs.items() if v is not None}
                 )
         # catch HTTPException: 400 Bad Request (error code: 50006): Cannot send an empty message
@@ -196,7 +196,7 @@ async def msgFormatter(self, webhook, message, json, editMsgId=None, deleteMsgId
                   "files": msgAttach,
                   "wait": True
                 }
-                whMsg = webhook.send(
+                whMsg = await webhook.send(
                     **{k: v for k, v in whMsgArgs.items() if v is not None}
                 )
             # One last try, without username or avatar
@@ -208,7 +208,7 @@ async def msgFormatter(self, webhook, message, json, editMsgId=None, deleteMsgId
                   "files": msgAttach,
                   "wait": True
                 }
-                whMsg = webhook.send(
+                whMsg = await webhook.send(
                     **{k: v for k, v in whMsgArgs.items() if v is not None}
                 )
     except Exception as err:

--- a/msgmover/utils.py
+++ b/msgmover/utils.py
@@ -1,0 +1,257 @@
+import asyncio
+import aiohttp
+import json
+import textwrap
+
+import discord
+
+import logging
+logger = logging.getLogger(__name__)
+
+
+WEBHOOK_EMPTY_AVATAR = "https://upload.wikimedia.org/wikipedia/commons/thumb/2/25/0-Background.svg/300px-0-Background.svg.png"
+WEBHOOK_EMPTY_NAME = "\u2e33\u2002\u2002\u2002\u2002\u2002\u2002\u2002\u2002\u2002\u2002\u2002\u2002\u2002\u2002\u2002\u2002\u2002\u2002\u2002\u2002\u2002\u2e33"
+
+
+
+async def msgFormatter(self, webhook, message, json, editMsgId=None, deleteMsgId=None):
+    # webhook: A webhook object from discord.py
+    # message: A message object from discord.py
+    # json: A {dict} with config variables
+
+    # Delete the message if it's delete
+    if deleteMsgId is not None:
+        try:
+            return webhook.delete_message(deleteMsgId)
+        except:
+            return False
+
+    # Edit the message if it's edit
+    if editMsgId is not None:
+        try:
+            return webhook.edit_message(
+                message_id=editMsgId,
+                content=message.clean_content
+            )
+        except discord.HTTPException:
+            return webhook.edit_message(
+                message_id=editMsgId,
+                content="**Discord:** Unsupported content\n"+str(message.clean_content)
+            )
+        except:
+            return False
+
+    # Check for system messages, Set up user profile
+    userProfilesName = None
+    userProfilesAvatar = None
+    if message.type == discord.MessageType.default or message.type == discord.MessageType.reply:
+        msgContent = message.clean_content
+        if json["userProfiles"] == True:
+            # (dpy-v2) "Discord" is not allowed in webhook usernames
+            userProfilesName = message.author.display_name.replace("Discord", "D🗪cord").replace("discord", "d🗪cord")
+            userProfilesAvatar = message.author.display_avatar.url
+    else:
+        msgContent = "**Discord:** "+str(message.type)
+        if json["userProfiles"] == True:
+            userProfilesName = WEBHOOK_EMPTY_NAME
+            userProfilesAvatar = WEBHOOK_EMPTY_AVATAR
+
+    # Add reply if exists
+    if message.reference and message.type == discord.MessageType.reply:
+        # Retrieve replied-to message
+        refObj = message.reference.resolved
+        replyEmbed = discord.Embed(color=discord.Color(value=0x25c059), description="")
+
+        # Fallback
+        if hasattr(refObj, "clean_content") is False:
+            refObj = message
+            refContent = "Message not found"
+            refUrl = ""
+        else:
+            refContent = refObj.clean_content
+            refUrl = refObj.jump_url
+        
+        # Fill content
+        if refContent:
+            replyBody = (refContent[:56] + '...') if len(refContent) > 56 else refContent
+        else:
+            replyBody = "Click to see attachment 🖼️"
+        # Create link to message
+        replyTitle = f"↪️ {replyBody}"
+        if json["userProfiles"] == True:
+            replyEmbed.set_author(name=replyTitle, icon_url=refObj.author.display_avatar.url, url=refUrl)
+        else:
+            replyEmbed.set_author(name=replyTitle, url=refUrl)
+        # Send this before the original message so that the embed appears above the message in chat
+        webhook.send(
+            username=userProfilesName,
+            avatar_url=userProfilesAvatar,
+            embed=replyEmbed
+        )
+        await asyncio.sleep(1)
+          
+
+    # Add embed if exists
+    msgEmbed = None
+    # Do not set the embed if it came from a http link in the message (fixes repo issue #4)
+    if message.embeds and "http" not in msgContent:
+        msgEmbed = message.embeds
+
+    # Add attachment if exists
+    msgAttach = None
+    if message.attachments:
+        attachMaxSize = 10000000 # 10MB, prev. 25MB, prev. 8MB
+        attachSuccess = False
+        if json["attachsAsUrl"] == False:
+            try:
+                # attachMaxSize upload limit
+                totalSize = 0
+                for mm in message.attachments:
+                    totalSize += mm.size
+                assert totalSize < attachMaxSize
+            except AssertionError:
+                # See if each file is under attachMaxSize, maybe we can send individually
+                for mm in message.attachments:
+                    try:
+                        assert mm.size < attachMaxSize
+                        webhook.send(
+                            username=userProfilesName,
+                            avatar_url=userProfilesAvatar,
+                            files=[await mm.to_file()],
+                            wait=True
+                        )
+                    except AssertionError:
+                        webhook.send(
+                            content="**Discord:** File too large\n"+str(mm.url),
+                            username=userProfilesName,
+                            avatar_url=userProfilesAvatar,
+                            wait=True
+                        )
+                attachSuccess = True
+            else:
+                msgAttach = [await msgA.to_file() for msgA in message.attachments]
+                attachSuccess = True
+        # Fallback if uploads don't work
+        if json["attachsAsUrl"] == True or attachSuccess == False:
+            for msgB in message.attachments:
+                msgContent += "\n"+str(msgB.url)
+
+    # Add activity if exists
+    if message.activity:
+        msgContent += f"\n**Discord:** Activity\n"+str(message.activity)
+    if message.application:
+        msgContent += f"\n**Discord:** {message.application.name}\n{message.application.description}"
+
+    # Add sticker if exists
+    if message.stickers:
+        for msgSticker in message.stickers:
+            if msgSticker.url is not None:
+                msgContent += "\n"+str(msgSticker.url)
+            else:
+                msgContent += "\n**Discord:** Sticker\n"+str(msgSticker.name)+", "+str(msgSticker.id)
+
+    # Send core message
+    whMsg = False
+
+    # (dpy-v2) Switch to argument unpacking, since passing None doesn't work anymore
+    whMsgArgs = {}
+
+    try:
+        whMsgArgs = {
+          "content": msgContent,
+          "username": userProfilesName,
+          "avatar_url": userProfilesAvatar,
+          "embeds": msgEmbed,
+          "files": msgAttach,
+          "wait": True
+        }
+        whMsg = webhook.send(
+            **{k: v for k, v in whMsgArgs.items() if v is not None}
+        )
+    except discord.HTTPException:
+        # catch HTTPException: 400 Bad Request (error code: 50035): Invalid Form Body
+        #     In content: Must be 2000 or fewer in length.
+        if len(msgContent) > 1964:
+            msgLines = textwrap.wrap(msgContent, 2000, break_long_words=True)
+            for msgLineItem in msgLines:
+                whMsgArgs = {
+                  "content": str(msgLineItem),
+                  "username": userProfilesName,
+                  "avatar_url": userProfilesAvatar,
+                  "embeds": msgEmbed,
+                  "files": msgAttach,
+                  "wait": True
+                }
+                whMsg = webhook.send(
+                    **{k: v for k, v in whMsgArgs.items() if v is not None}
+                )
+        # catch HTTPException: 400 Bad Request (error code: 50006): Cannot send an empty message
+        else:
+            try:
+                whMsgArgs = {
+                  "content": "**Discord:** Unsupported content\n" + str(msgContent[:1964]) + (str(msgContent[1964:]) and '…'),
+                  "username": userProfilesName,
+                  "avatar_url": userProfilesAvatar,
+                  "embeds": msgEmbed,
+                  "files": msgAttach,
+                  "wait": True
+                }
+                whMsg = webhook.send(
+                    **{k: v for k, v in whMsgArgs.items() if v is not None}
+                )
+            # One last try, without username or avatar
+            except:
+                whMsgArgs = {
+                  "content": "**Discord:** Unsupported content\n" + str(msgContent[:1964]) + (str(msgContent[1964:]) and '…'),
+                  "username": "Unknown User",
+                  "embeds": msgEmbed,
+                  "files": msgAttach,
+                  "wait": True
+                }
+                whMsg = webhook.send(
+                    **{k: v for k, v in whMsgArgs.items() if v is not None}
+                )
+    except Exception as err:
+        logger.error(err)
+        # traceback.print_exc()
+        return False
+    
+    # Need to tell endpoint that function ended, so that sent message order is enforceable by await
+    return whMsg
+
+
+def webhookSettings(json):
+    """
+    Default settings for sending webhooks
+    """
+    relayInfo = {
+        "toWebhook": json.get("toWebhook", ""),
+        "attachsAsUrl": json.get("attachsAsUrl", True),
+        "userProfiles": json.get("userProfiles", True),
+    }
+    return relayInfo
+
+
+async def webhookFinder(self, channel):
+    # 2025-03-09 TODO: Update generic Exception to specific error cases
+
+    # Find a webhook that the bot made
+    try:
+        whooklist = await channel.webhooks()
+    except Exception as err:
+        # Could not fetch webhooks, exit
+        logger.error(err)
+        return False
+    # Fetch webhooks success, check for match
+    for wh in whooklist:
+        # Found match
+        if self.bot.user == wh.user:
+            return wh.url
+    # If the function got here, it means there isn't one that the bot made
+    try:
+        newHook = await channel.create_webhook(name="Webhook")
+        return newHook.url
+    # Could not create webhook, return False
+    except Exception as err:
+        logger.error(err)
+        return False

--- a/msgmover/utils_copy.py
+++ b/msgmover/utils_copy.py
@@ -1,0 +1,13 @@
+import discord
+
+from .utils import *
+
+import logging
+logger = logging.getLogger(__name__)
+
+
+async def timestampEmbed(self, ctx, utcTimeObj):
+    embedColor = await ctx.embed_colour()
+    embed = discord.Embed(color=embedColor, timestamp=utcTimeObj)
+    embed.set_footer(text='\u200b')
+    return embed

--- a/msgmover/utils_relay.py
+++ b/msgmover/utils_relay.py
@@ -1,0 +1,90 @@
+import asyncio
+
+from redbot.core.utils.predicates import ReactionPredicate
+from redbot.core.utils.menus import start_adding_reactions
+import discord
+
+from .utils import webhookSettings, webhookFinder
+
+import logging
+logger = logging.getLogger(__name__)
+
+
+relayGetData = webhookSettings
+
+
+async def relayAddChannel(self, ctx, chanObj, toWebhook):
+    msgrelayStoreV2 = await self.config.guild(ctx.guild).msgrelayStoreV2()
+    
+    # Set attachsAsUrl
+    attachsAsUrl = await ctx.send("Do you want attachments (images) to be forwarded as links?\n> **Yes:** Images will be sent as links\n> **No:** Images will be re-uploaded as a new file")
+    start_adding_reactions(attachsAsUrl, ReactionPredicate.YES_OR_NO_EMOJIS)
+    attachsAsUrlPred = ReactionPredicate.yes_or_no(attachsAsUrl, ctx.author)
+    try:
+        await ctx.bot.wait_for("reaction_add", timeout=30, check=attachsAsUrlPred)
+    except asyncio.TimeoutError:
+        return False
+
+    # Set userProfiles
+    userProfiles = await ctx.send("Do you want messages to be forwarded with profiles?\n> **Yes:** Messages will be forwarded with usernames and profile pics\n> **No:** Messages will use the webhook's name and image instead")
+    start_adding_reactions(userProfiles, ReactionPredicate.YES_OR_NO_EMOJIS)
+    userProfilesPred = ReactionPredicate.yes_or_no(userProfiles, ctx.author)
+    try:
+        await ctx.bot.wait_for("reaction_add", timeout=30, check=userProfilesPred)
+    except asyncio.TimeoutError:
+        return False
+
+    # Create data store
+    try:
+        relayInfo = {
+            "toWebhook": str(toWebhook),
+            "attachsAsUrl": attachsAsUrlPred.result,
+            "userProfiles": userProfilesPred.result,
+        }
+    except Exception as err:
+        logger.error(f"relayAddChannel: Creating relay info failed: {err}")
+        return False
+
+    # Append to data
+    try:
+        msgrelayStoreV2[str(chanObj.id)].append(relayInfo)
+    except KeyError:
+        msgrelayStoreV2[str(chanObj.id)] = [relayInfo]
+    except Exception as err:
+        logger.error(f"relayAddChannel: Saving data failed: {err}")
+        return False
+
+    # Return changes
+    return msgrelayStoreV2
+
+
+async def relayRemoveChannel(self, ctx, channel, itemToDelete):
+    # Retrieve stored data
+    msgrelayStoreV2 = await self.config.guild(ctx.guild).msgrelayStoreV2()
+
+    # Remove from data
+    if itemToDelete <= 0:
+        msgrelayStoreV2.pop(str(channel.id), None)
+    else:
+        # Zero-indexed
+        msgrelayStoreV2[str(channel.id)].pop(itemToDelete-1)
+
+    # Push changes
+    await self.config.guild(ctx.guild).msgrelayStoreV2.set(msgrelayStoreV2)
+    return True
+
+
+async def relayCheckInput(self, ctx, toChannel):
+    # Find/create webhook at destination if input is a channel
+    if isinstance(toChannel, discord.TextChannel):
+        toWebhook = await webhookFinder(self, toChannel)
+        if toWebhook == False:
+            await ctx.send("An error occurred: could not create webhook. Am I missing permissions?")
+            return False
+        return toWebhook
+    # Use webhook url as-is if there is https link (doesn't have to be Discord)
+    if "https://" in toChannel:
+        return str(toChannel)
+    # Error likely occurred, return False
+    await ctx.send("Error: Channel is not in this server, or webhook URL is invalid.\n\nIf you're trying to move messages across servers, please create a Webhook in the channel you want to send to: https://support.discord.com/hc/article_attachments/1500000463501/Screen_Shot_2020-12-15_at_4.41.53_PM.png")
+    return False

--- a/msgmover/utils_relay.py
+++ b/msgmover/utils_relay.py
@@ -88,3 +88,17 @@ async def relayCheckInput(self, ctx, toChannel):
     # Error likely occurred, return False
     await ctx.send("Error: Channel is not in this server, or webhook URL is invalid.\n\nIf you're trying to move messages across servers, please create a Webhook in the channel you want to send to: https://support.discord.com/hc/article_attachments/1500000463501/Screen_Shot_2020-12-15_at_4.41.53_PM.png")
     return False
+
+
+
+# Legacy Commands
+
+async def fixMsgrelayStoreV2alpha(self, ctx):
+    oldData = await self.config.guild(ctx.guild).msgrelayStoreV2()
+    if isinstance(oldData[str(ctx.channel.id)], list) == False:
+        newData = [oldData[str(ctx.channel.id)]]
+        oldData[str(ctx.channel.id)] = newData
+        await self.config.guild(ctx.guild).msgrelayStoreV2.set(oldData)
+        return newData
+    else:
+        return oldData[str(ctx.channel.id)]


### PR DESCRIPTION
#45

MsgMover

- [x]     :memo: Commands do not check if the bot has add_reactions permissions where needed.
- [x]     Commands do not check if the bot has read_message_history permissions where needed.
- [x]     With the new “forward” feature in discord, you can consider if this cog is still needed, or try to market its strengths over that system.
  - Also consider “announcement channels” as another competing discord feature.
  - **Response:**
  Msgmover does not compete with these features. It is still difficult to forward all messages for a channel merge, or to have a conversation across servers (or other Discord-webhook-compatible bridges). Announcement channels are even more limited, with only manual pushes and opt-ins. The docs shall be rewritten to reflect this.
- [x]     Why does the [p]msgmover group exist with no subcommands and a docstring that reads like an install_msg? Just put that message into the install_msg?
- [x]     The legacy commands should probably be hidden.
- [x]     discord.errors is technically private. Rather than using discord.errors.NotFound, it is preferred to use discord.NotFound. (A traceback has the full path because that is how Python sees it, but the shorter version is the documented way to call it that is covered by version guarantees)
- [x]     :memo: [p]msgcopy doesn’t handle non-positive message counts or negative skip values nicely:
     ```
     Traceback (most recent call last):
       File "datapath\cogs\CogManager\cogs\msgmover\msgmover.py", line 213, in msgcopy
         msgItemLast = msgList[0].created_at
     IndexError: list index out of range
     ```
- [x]     I have no idea what itemToEdit is supposed to be in [p]msgrelay edit.
  - Assuming it is supposed to be an index like [p]msgrelay delete, the converter for the second channel/webhook is not a union of TextChannel and str, so passing a channel incorrectly causes a fail state.
  - **Response:**
  Yes, each channel can have multiple outgoing relays. itemToEdit is for selecting which relay to edit. This is now fixed, and the docstring updated.

General

- [see #45]     Consider using TitleCase instead of Titlecase casing for your class names to maintain consistency with how users expect to get [p]help for 3rd party cogs.
- [x]     :memo: Several of your cogs use requests (or urllib.requests), which is a [blocking](https://discordpy.readthedocs.io/en/latest/faq.html#what-does-blocking-mean) way to make HTTP requests. You should instead use aiohttp (as several of your cogs do) to make HTTP requests in an asynchronous way.
- [x]     :memo: Some cogs have requests in their requirements, despite it not being used.
- [x]     Some cogs have aiohttp and asyncio in their requirements. Those libraries are already requirements of Red, so listing them is not necessary.
- [see #45]     Despite some cogs including it, permissions is not a valid info.json key, and including it will not resolve the need to add proper permissions checking to commands.
- [x]     You have bare except blocks in a few places. Consider at least replacing them with except Exception, to avoid catching standard control errors like the one generated by CTRL+Cing. Ideally, identify the error you actually intend to catch and use that instead (generally discord.HTTPException is a good bet for Discord API calls).
- [?]     Consider checking the response.status in your aiohttp requests in case the URL requested goes offline or has an error.
- [see #45]     Consider using await ctx.tick() instead of a manual add_reaction call in places where you are just adding a checkmark to the invoking message.