### PR TITLE
Red Cog Approval: sendhook

### DIFF
--- a/sendhook/info.json
+++ b/sendhook/info.json
@@ -3,7 +3,7 @@
   "install_msg" : "Thanks for installing, I hope you enjoy :) To stay up to date with breaking changes, you might want to join my Support Discord. To find documentation, Discord, and more, drop by my site at https://coffeebank.github.io/coffee-cogs/sendhook/",
   "name" : "sendhook",
   "short" : "The comprehensive webhooks cog, with sending, listing, and creating of webhooks",
-  "requirements" : ["requests"],
+  "requirements" : [],
   "description" : "The comprehensive webhooks cog, with sending, listing, and creating of webhooks. Comes with support for webhook aliases and sending messages as your username/avatar. Perfect for users stuck on mobile Discord.",
   "permissions" : [],
   "end_user_data_statement" : "This cog does not store any End User Data.",

--- a/sendhook/sendhook.py
+++ b/sendhook/sendhook.py
@@ -280,6 +280,8 @@ class Sendhook(commands.Cog):
         # Try to parse JSON
         try:
             contentJson = json.loads(webhookJson)
+        except json.JSONDecodeError as err:
+            return await ctx.send("Error: JSON Input - "+str(err))
         except Exception as err:
             logger.error(err, exc_info=True)
             return await ctx.send("Error: "+str(err))
@@ -409,6 +411,8 @@ class Sendhook(commands.Cog):
         # Try to parse JSON
         try:
             contentJson = json.loads(webhookJson)
+        except json.JSONDecodeError as err:
+            return await ctx.send("Error: JSON Input - "+str(err))
         except Exception as err:
             logger.error(err, exc_info=True)
             return await ctx.send("Error: "+str(err))

--- a/sendhook/sendhook.py
+++ b/sendhook/sendhook.py
@@ -73,7 +73,7 @@ class Sendhook(commands.Cog):
             pass
 
     @aliashook.command(name="add")
-    async def ahadd(self, ctx, alias, webhookUrl):
+    async def ahadd(self, ctx, alias: str, webhookUrl: str):
         """Add an alias for a webhook"""
         webhookAlias = await self.config.guild(ctx.guild).webhookAlias()
         webhookAlias[alias] = webhookUrl
@@ -85,7 +85,7 @@ class Sendhook(commands.Cog):
             await ctx.send("Webhook alias added ✅")
 
     @aliashook.command(name="remove")
-    async def ahremove(self, ctx, alias):
+    async def ahremove(self, ctx, alias: str):
         """Remove an alias for a webhook"""
         webhookAlias = await self.config.guild(ctx.guild).webhookAlias()
         try:
@@ -109,7 +109,7 @@ class Sendhook(commands.Cog):
         await ctx.send("```json\n"+webhookData+"```")
 
     @aliashook.command(name="show")
-    async def ahshow(self, ctx, alias):
+    async def ahshow(self, ctx, alias: str):
         """Show the saved webhook url for an alias"""
         webhookAlias = await self.config.guild(ctx.guild).webhookAlias()
         webhookData = webhookAlias[alias]
@@ -120,7 +120,7 @@ class Sendhook(commands.Cog):
 
     @commands.command()
     @checks.mod()
-    async def sendhook(self, ctx, webhookUrl, *, webhookText=None):
+    async def sendhook(self, ctx, webhookUrl: str, *, webhookText: str=None):
         """Send a webhook
         
         webhookUrl can be an alias"""
@@ -145,7 +145,7 @@ class Sendhook(commands.Cog):
 
     @commands.command()
     @checks.mod()
-    async def sendhookself(self, ctx, webhookUrl, *, webhookText=None):
+    async def sendhookself(self, ctx, webhookUrl: str, *, webhookText: str=None):
         """Send a webhook as yourself
         
         webhookUrl can be an alias"""
@@ -170,7 +170,7 @@ class Sendhook(commands.Cog):
 
     @commands.command()
     @checks.mod()
-    async def edithook(self, ctx, webhookUrl, messageId, *, webhookText):
+    async def edithook(self, ctx, webhookUrl: str, messageId: str, *, webhookText: str):
         """Edit a message sent by a webhook
         
         webhookUrl can be an alias"""
@@ -212,7 +212,7 @@ class Sendhook(commands.Cog):
 
     @commands.command()
     @checks.mod()
-    async def newhook(self, ctx, webhookName, webhookImage, channel: discord.TextChannel=None):
+    async def newhook(self, ctx, webhookName: str, webhookImage: str="", channel: discord.TextChannel=None):
         """Create a webhook"""
         if channel == None:
             channel = ctx.message.channel

--- a/sendhook/sendhook.py
+++ b/sendhook/sendhook.py
@@ -1,14 +1,32 @@
-from redbot.core import Config, commands, checks
-# from array import *
-import discord
-from discord import Webhook, SyncWebhook
-import aiohttp
 import asyncio
-import requests
 import json
 
+from redbot.core import Config, commands
+import discord
+from discord import Webhook
+import aiohttp
+
+from .utils import *
+
+import logging
+logger = logging.getLogger(__name__)
+
+
 class Sendhook(commands.Cog):
-    """Send webhooks easily..."""
+    """Send and edit webhook messages easily...
+    
+    To get started, send to a webhook URL using **`[p]sendhook`**
+
+    You can set up aliases to mask the webhook URL, and make sending messages more convenient, using **`[p]aliashook`**
+
+    The JSON commands support https://discohook.org message designs, including sending embeds.
+
+    More details: [See FAQ & full documentation >](https://coffeebank.github.io/coffee-cogs/sendhook)
+
+    -
+
+    ⚠️ Webhook URLs are sensitive information. **Anyone can use them to send messages into your chat!** Please only run these commands in private guild channels.
+    """
 
     def __init__(self):
         self.config = Config.get_conf(self, identifier=806715409318936616)
@@ -24,67 +42,59 @@ class Sendhook(commands.Cog):
         pass
 
 
-    # Utility Commands
-
-    async def sendhookEngine(self, toWebhook, messageObj, webhookText=None, webhookUser=None, webhookAvatar=None):
-        # Start webhook session
-        webhook = SyncWebhook.from_url(toWebhook)
-
-        # Check for attachments
-        if messageObj.attachments:
-            # Send message first if there is a message
-            if webhookText is not None:
-                webhook.send(
-                    webhookText,
-                    username=webhookUser,
-                    avatar_url=webhookAvatar
-                )
-            # Then send each attachment in separate messages
-            for msgAttach in messageObj.attachments:
-                try:
-                    webhook.send(
-                        username=webhookUser,
-                        avatar_url=webhookAvatar,
-                        file=await msgAttach.to_file()
-                    )
-                except:
-                    # Couldn't send, retry sending file as url only
-                    webhook.send(
-                        "File: "+str(msgAttach.url), 
-                        username=webhookUser,
-                        avatar_url=webhookAvatar
-                    )
-        else:
-            webhook.send(
-                webhookText,
-                username=webhookUser,
-                avatar_url=webhookAvatar
-            )
-
 
     # Bot Commands
 
     @commands.guild_only()
     @commands.group()
-    @checks.mod()
+    @commands.has_permissions(manage_guild=True, manage_webhooks=True)
+    @commands.bot_has_permissions(manage_webhooks=True)
     async def aliashook(self, ctx: commands.Context):
-        """Configure aliases for webhooks in your server"""
+        """Configure aliases for webhooks in your server
+
+        -
+
+        ⚠️ Webhook URLs are sensitive information. **Anyone can use them to send messages into your chat!** Please only run these commands in private guild channels.
+        """
         if not ctx.invoked_subcommand:
             pass
 
     @aliashook.command(name="add")
+    @commands.has_permissions(manage_guild=True, manage_webhooks=True)
+    @commands.bot_has_permissions(manage_messages=True)
     async def ahadd(self, ctx, alias: str, webhookUrl: str):
-        """Add an alias for a webhook"""
+        """Add an alias for a webhook (⚠️ Sensitive info)
+        
+        To create an alias, you need a webhook URL.
+
+        Create a webhook in Discord settings, or use **`[p]sendhooktools newhook`**
+
+        ⚠️ Webhook URLs are sensitive information. **Anyone can use them to send messages into your chat!** Please only run these commands in private guild channels. Once the bot receives your command, it will be deleted, for security purposes.
+        """
+
+        # Immediately delete the command message, to hide webhook URL
+        await ctx.message.delete()
+        creating = await ctx.send("Creating ⏳")
+
         webhookAlias = await self.config.guild(ctx.guild).webhookAlias()
         webhookAlias[alias] = webhookUrl
         await self.config.guild(ctx.guild).webhookAlias.set(webhookAlias)
-        # Try adding react, if no perms then send normal message
+        # Try to clear the loading prompt, but not important even if it fails
         try:
-            await ctx.message.add_reaction("✅")
-        except:
-            await ctx.send("Webhook alias added ✅")
+            await creating.delete()
+        except discord.NotFound:
+            pass
+        except Exception as err:
+            logger.error(err)
+            pass
+        # Success
+        try:
+            await creating.edit(content="Webhook alias added successfully. ✅")
+        except Exception:
+            await ctx.send("Webhook alias added successfully. ✅")
 
     @aliashook.command(name="remove")
+    @commands.has_permissions(manage_guild=True, manage_webhooks=True)
     async def ahremove(self, ctx, alias: str):
         """Remove an alias for a webhook"""
         webhookAlias = await self.config.guild(ctx.guild).webhookAlias()
@@ -93,163 +103,435 @@ class Sendhook(commands.Cog):
             webhookAlias[alias] = ""
             del webhookAlias[alias]
             await self.config.guild(ctx.guild).webhookAlias.set(webhookAlias)
-            # Try adding react, if no perms then send normal message
-            try:
+            # Success
+            if ctx.channel.permissions_for(ctx.guild.me).add_reactions:
                 await ctx.message.add_reaction("✅")
-            except:
-                await ctx.send("Webhook alias removed ✅")
+            else:
+                await ctx.send("Done ✅")
         except KeyError:
             pass
 
     @aliashook.command(name="list")
-    async def ahlist(self, ctx):
-        """List all aliases for webhooks"""
+    @commands.has_permissions(manage_guild=True, manage_webhooks=True)
+    async def ahlist(self, ctx, safeMode: bool=True):
+        """List all aliases for webhooks
+
+        Safe Mode:
+        - (Default) Send `True` to only include snippet (4 char.) Webhook URL.
+        - Send `False` to include full Webhook URL.
+
+        -
+
+        ⚠️ Webhook URLs are sensitive information. **Anyone can use them to send messages into your chat!** Please only run these commands in private guild channels.
+        """
         webhookAlias = await self.config.guild(ctx.guild).webhookAlias()
-        webhookData = json.dumps(webhookAlias, sort_keys=True, indent=2, separators=(',', ': '))
-        await ctx.send("```json\n"+webhookData+"```")
+
+        # Exit if empty
+        if len(webhookAlias.items()) <= 0:
+            return await ctx.send("No webhook aliases found in this guild.")
+
+        returntext = ""
+        for name, url in webhookAlias.items():
+            if safeMode == True:
+                returntext += "- "+name+" - …"+url[-4:]+"\n"
+            else:
+                returntext += "- "+name+" - ||"+url+"||\n"
+        await ctx.send(returntext[:1999])
 
     @aliashook.command(name="show")
+    @commands.has_permissions(manage_guild=True, manage_webhooks=True)
     async def ahshow(self, ctx, alias: str):
-        """Show the saved webhook url for an alias"""
+        """Show the saved webhook url for an alias (⚠️ Sensitive info)
+
+        ⚠️ Webhook URLs are sensitive information. **Anyone can use them to send messages into your chat!** Please only run these commands in private guild channels.
+        """
         webhookAlias = await self.config.guild(ctx.guild).webhookAlias()
-        webhookData = webhookAlias[alias]
-        await ctx.send("```"+webhookData+"```")
+        webhookData = webhookAlias.get(alias, None)
+        if webhookData:
+            await ctx.send("||"+webhookData[:1995]+"||")
+        else:
+            await ctx.send("Error: Couldn't fetch alias. Did you type it correctly?")
 
-
-    # @commands.bot_has_permissions(embed_links=True, add_reactions=True)
 
     @commands.command()
-    @checks.mod()
-    async def sendhook(self, ctx, webhookUrl: str, *, webhookText: str=None):
-        """Send a webhook
+    @commands.has_permissions(manage_webhooks=True)
+    @commands.bot_has_permissions(manage_webhooks=True, embed_links=True)
+    async def sendhook(self, ctx, webhookUrl_or_alias: str, *, webhookText: str=None):
+        """Send a message through a webhook (⚠️ Sensitive info)
         
-        webhookUrl can be an alias"""
+        You can set up aliases to mask the webhook URL, and make sending messages more convenient. For bot setup details, see **`[p]help Sendhook`**
 
-        message = ctx.message
+        **Required user permissions:** Manage Webhooks.
 
-        # Check if webhookUrl is an alias
-        webhookAlias = await self.config.guild(ctx.guild).webhookAlias()
-        if webhookUrl in webhookAlias:
-            toWebhook = webhookAlias[webhookUrl]
-        else:
-            toWebhook = webhookUrl
+        -
+        
+        ⚠️ Webhook URLs are sensitive information. **Anyone can use them to send messages into your chat!** Please only run these commands in private guild channels.
+        
+        Once the bot receives your command, it will be deleted, for security purposes.
+        """
+        creating = await ctx.send("Sending ⏳")
+
+        # Check if it is an alias
+        try:
+            toWebhook = await validateWebhookInput(self, ctx, webhookUrl_or_alias)
+        except commands.UserInputError as err:
+            return await ctx.send(err)
 
         # Send webhook
         try:
-            await self.sendhookEngine(toWebhook, message, webhookText)
-        except:
-            await ctx.send("Oops, an error occurred :'(")
+            await sendhookEngine(toWebhook, content=webhookText, attachments=ctx.message.attachments)
+        except ValueError as err:
+            try:
+                await creating.edit(content="Error: "+str(err))
+            except Exception:
+                await ctx.send("Error: "+str(err))
+        except Exception as err:
+            logger.error(err, exc_info=True)
+            err_text = "Oops, an error occurred :'( Please see bot logs for details..."
+            try:
+                await creating.edit(content=err_text)
+            except Exception:
+                await ctx.send(err_text)
         else:
-            await ctx.message.add_reaction("✅")
+            # Success
+            try:
+                await creating.edit(content="Sent successfully. ✅")
+                # Delete the command message, to hide webhook URL, after all attachments uploaded, silently fail OK
+                await ctx.message.delete()
+            except Exception:
+                await ctx.send("Sent successfully. ✅")
 
 
     @commands.command()
-    @checks.mod()
-    async def sendhookself(self, ctx, webhookUrl: str, *, webhookText: str=None):
-        """Send a webhook as yourself
+    @commands.has_permissions(manage_webhooks=True)
+    @commands.bot_has_permissions(manage_webhooks=True, embed_links=True)
+    async def sendhookself(self, ctx, webhookUrl_or_alias: str, *, webhookText: str=None):
+        """Send a webhook as yourself (⚠️ Sensitive info)
+
+        You can set up aliases to mask the webhook URL, and make sending messages more convenient. For bot setup details, see **`[p]help Sendhook`**
+
+        **Required user permissions:** Manage Webhooks.
+
+        -
         
-        webhookUrl can be an alias"""
+        ⚠️ Webhook URLs are sensitive information. **Anyone can use them to send messages into your chat!** Please only run these commands in private guild channels.
+        
+        Once the bot receives your command, it will be deleted, for security purposes.
+        """
+        creating = await ctx.send("Sending ⏳")
 
-        message = ctx.message
-
-        # Check if webhookUrl is an alias
-        webhookAlias = await self.config.guild(ctx.guild).webhookAlias()
-        if webhookUrl in webhookAlias:
-            toWebhook = webhookAlias[webhookUrl]
-        else:
-            toWebhook = webhookUrl
+        # Check if it is an alias
+        try:
+            toWebhook = await validateWebhookInput(self, ctx, webhookUrl_or_alias)
+        except commands.UserInputError as err:
+            return await ctx.send(err)
 
         # Send webhook
         try:
-            await self.sendhookEngine(toWebhook, message, webhookText, message.author.display_name, message.author.display_avatar.url)
-        except:
-            await ctx.send("Oops, an error occurred :'(")
+            await sendhookEngine(toWebhook, content=webhookText, attachments=ctx.message.attachments, webhookUser=ctx.message.author.display_name, webhookAvatar=ctx.message.author.display_avatar.url)
+        except ValueError as err:
+            try:
+                await creating.edit(content="Error: "+str(err))
+            except Exception:
+                await ctx.send("Error: "+str(err))
+        except Exception as err:
+            logger.error(err, exc_info=True)
+            err_text = "Oops, an error occurred :'( Please see bot logs for details..."
+            try:
+                await creating.edit(content=err_text)
+            except Exception:
+                await ctx.send(err_text)
         else:
-            await ctx.message.add_reaction("✅")
+            # Success
+            try:
+                await creating.edit(content="Sent successfully. ✅")
+                # Delete the command message, to hide webhook URL, after all attachments uploaded, silently fail OK
+                await ctx.message.delete()
+            except Exception:
+                await ctx.send("Sent successfully. ✅")
 
 
     @commands.command()
-    @checks.mod()
-    async def edithook(self, ctx, webhookUrl: str, messageId: str, *, webhookText: str):
-        """Edit a message sent by a webhook
+    @commands.has_permissions(manage_webhooks=True)
+    @commands.bot_has_permissions(manage_webhooks=True, embed_links=True)
+    async def sendhookjson(self, ctx, webhookUrl_or_alias: str, *, webhookJson: str):
+        """Send a message through a webhook, using JSON (⚠️ Sensitive info)
+
+        Supports embeds.
+
+        Use https://discohook.org to design your message, then click "JSON Data Editor" at the bottom, "Copy to Clipboard", and send here.
+
+        -
         
-        webhookUrl can be an alias"""
+        ⚠️ Webhook URLs are sensitive information. **Anyone can use them to send messages into your chat!** Please only run these commands in private guild channels.
+        
+        Once the bot receives your command, it will be deleted, for security purposes.
+        
+        For bot setup details, see **`[p]help Sendhook`**
+        """
+        creating = await ctx.send("Sending ⏳")
+
+        # Check if it is an alias
+        try:
+            toWebhook = await validateWebhookInput(self, ctx, webhookUrl_or_alias)
+        except commands.UserInputError as err:
+            return await ctx.send(err)
+
+        # Try to parse JSON
+        try:
+            contentJson = json.loads(webhookJson)
+        except Exception as err:
+            logger.error(err, exc_info=True)
+            return await ctx.send("Error: "+str(err))
+
+        # Send webhook
+        try:
+            await sendhookEngine(toWebhook, content=contentJson.get("content", None), embeds=contentJson.get("embeds", None))
+        except ValueError as err:
+            try:
+                await creating.edit(content="Error: "+str(err))
+            except Exception:
+                await ctx.send("Error: "+str(err))
+        except Exception as err:
+            logger.error(err, exc_info=True)
+            err_text = "Oops, an error occurred :'( Please see bot logs for details..."
+            try:
+                await creating.edit(content=err_text)
+            except Exception:
+                await ctx.send(err_text)
+        else:
+            # Success
+            try:
+                await creating.edit(content="Sent successfully. ✅")
+                # Delete the command message, to hide webhook URL, after all attachments uploaded, silently fail OK
+                await ctx.message.delete()
+            except Exception:
+                await ctx.send("Sent successfully. ✅")
+
+
+    @commands.command()
+    @commands.has_permissions(manage_messages=True, manage_webhooks=True)
+    @commands.bot_has_permissions(manage_webhooks=True, embed_links=True)
+    async def edithook(self, ctx, webhookUrl_or_alias: str, messageId: str, *, webhookText: str):
+        """Edit a message sent by a webhook (⚠️ Sensitive info)
+
+        You can set up aliases to mask the webhook URL, and make sending messages more convenient. For bot setup details, see **`[p]help Sendhook`**
+
+        **Required user permissions:** Manage Messages, Manage Webhooks.
+
+        -
+        
+        ⚠️ Webhook URLs are sensitive information. **Anyone can use them to send messages into your chat!** Please only run these commands in private guild channels.
+        
+        Once the bot receives your command, it will be deleted, for security purposes.
+        """
+        creating = await ctx.send("Sending ⏳")
 
         # Formatting the messageId
-        forgotMsgLink = "Oh no! Did you remember to include the message link to the message you want to edit?"
-        if isinstance(messageId, str):
+        if "/" in messageId:
             try:
                 messageId = int(messageId.split('/')[-1])
-            except:
-                await ctx.send(forgotMsgLink)
-        elif isinstance(messageId, int):
+            except Exception:
+                return await ctx.send("Error: Not a valid Discord message link.")
+        else:
+            try:
+                messageId = int(messageId)
+            except Exception:
+                return await ctx.send("Error: Message ID should be a string of numbers.")
+
+        # Check if it is an alias
+        try:
+            toWebhook = await validateWebhookInput(self, ctx, webhookUrl_or_alias)
+        except commands.UserInputError as err:
+            return await ctx.send(err)
+
+        # Send webhook
+        try:
+            await edithookEngine(toWebhook=toWebhook, messageIdToEdit=messageId, content=webhookText)
+        except ValueError as err:
+            try:
+                await creating.edit(content="Error: "+str(err))
+            except Exception:
+                await ctx.send("Error: "+str(err))
+        except Exception as err:
+            logger.error(err, exc_info=True)
+            err_text = "Oops, an error occurred :'( Please see bot logs for details..."
+            try:
+                await creating.edit(content=err_text)
+            except Exception:
+                await ctx.send(err_text)
+        else:
+            # Success
+            try:
+                await creating.edit(content="Sent successfully. ✅")
+                # Delete the command message, to hide webhook URL, after all attachments uploaded, silently fail OK
+                await ctx.message.delete()
+            except Exception:
+                await ctx.send("Sent successfully. ✅")
+
+
+    @commands.command()
+    @commands.has_permissions(manage_messages=True, manage_webhooks=True)
+    @commands.bot_has_permissions(manage_webhooks=True, embed_links=True)
+    async def edithookjson(self, ctx, webhookUrl_or_alias: str, messageId: str, *, webhookJson: str):
+        """Edit a message sent by a webhook, using JSON (⚠️ Sensitive info)
+
+        Supports embeds.
+
+        Use https://discohook.org to design your message, then click "JSON Data Editor" at the bottom, "Copy to Clipboard", and send here.
+
+        -
+        
+        ⚠️ Webhook URLs are sensitive information. **Anyone can use them to send messages into your chat!** Please only run these commands in private guild channels.
+        
+        Once the bot receives your command, it will be deleted, for security purposes.
+        """
+        creating = await ctx.send("Sending ⏳")
+
+        # Formatting the messageId
+        if "/" in messageId:
+            try:
+                messageId = int(messageId.split('/')[-1])
+            except Exception:
+                return await ctx.send("Error: Not a valid Discord message link.")
+        else:
+            try:
+                messageId = int(messageId)
+            except Exception:
+                return await ctx.send("Error: Message ID should be a string of numbers.")
+
+        # Check if it is an alias
+        try:
+            toWebhook = await validateWebhookInput(self, ctx, webhookUrl_or_alias)
+        except commands.UserInputError as err:
+            return await ctx.send(err)
+
+        # Try to parse JSON
+        try:
+            contentJson = json.loads(webhookJson)
+        except Exception as err:
+            logger.error(err, exc_info=True)
+            return await ctx.send("Error: "+str(err))
+
+        # Send webhook
+        try:
+            await edithookEngine(toWebhook=toWebhook, messageIdToEdit=messageId, content=contentJson.get("content", None), embeds=contentJson.get("embeds", None))
+        except ValueError as err:
+            try:
+                await creating.edit(content="Error: "+str(err))
+            except Exception:
+                await ctx.send("Error: "+str(err))
+        except Exception as err:
+            logger.error(err, exc_info=True)
+            err_text = "Oops, an error occurred :'( Please see bot logs for details..."
+            try:
+                await creating.edit(content=err_text)
+            except Exception:
+                await ctx.send(err_text)
+        else:
+            # Success
+            try:
+                await creating.edit(content="Sent successfully. ✅")
+                # Delete the command message, to hide webhook URL, after all attachments uploaded, silently fail OK
+                await ctx.message.delete()
+            except Exception:
+                await ctx.send("Sent successfully. ✅")
+
+
+    @commands.guild_only()
+    @commands.group()
+    @commands.has_permissions(manage_webhooks=True)
+    @commands.bot_has_permissions(manage_webhooks=True)
+    async def sendhooktools(self, ctx: commands.Context):
+        """Tools for working with webhooks
+
+        Quick tools to configure webhooks on the go
+
+        Many commands are now available directly in Discord Mobile:
+        See `#channel settings` > `Integrations` > `Webhooks`
+
+        -
+
+        ⚠️ Webhook URLs are sensitive information. **Anyone can use them to send messages into your chat!** Please only run these commands in private guild channels.
+        """
+        if not ctx.invoked_subcommand:
             pass
-        else:
-            await ctx.send(forgotMsgLink)
 
-        # Check if webhookUrl is an alias
-        webhookAlias = await self.config.guild(ctx.guild).webhookAlias()
-        if webhookUrl in webhookAlias:
-            url = str(webhookAlias[webhookUrl]) + "/messages/" + str(messageId)
-        else:
-            url = str(webhookUrl) + "/messages/" + str(messageId)
+    @sendhooktools.command()
+    @commands.has_permissions(manage_webhooks=True)
+    @commands.bot_has_permissions(manage_webhooks=True, embed_links=True)
+    async def newhook(self, ctx, webhookName: str, webhookImage: str=None, channel: discord.TextChannel=None):
+        """Create a webhook in a channel (⚠️ Sensitive info)
+        
+        - webhookName: Name of webhook
+        - webhookImage *(optional)*: URL of image to fetch, for webhook avatar (profile pic)
+        - channel *(optional)*: Channel to create webhook in (default: current channel)
 
-        # Formatting the payload
-        head = {"Content-Type":"application/json"}
-        payload = {"content": str(webhookText) }
+        ⚠️ Webhook URLs are sensitive information. **Anyone can use them to send messages into your chat!** Please only run these commands in private guild channels.
+        """
+        if channel == None:
+            channel = ctx.message.channel
+        # Loading
+        if ctx.channel.permissions_for(ctx.guild.me).add_reactions:
+            await ctx.message.add_reaction("⏳")
+        else:
+            await ctx.send("Loading ⏳")
+        await ctx.send(str(channel.mention)+" "+str(channel.id))
+
+        wimgdata = None
+        if webhookImage:
+            async with aiohttp.ClientSession() as session:
+                async with session.get(webhookImage) as resp:
+                    if resp.status != 200:
+                        return await channel.send('Could not fetch image... Server error.')
+                    try:
+                        wimgdata = await resp.read()
+                    except Exception as err:
+                        logger.error(err)
+                        return await channel.send('Could not fetch image... Response error.')
 
         try:
-            requests.patch(url, json=payload, headers=head)
-        except:
-            await ctx.send("Oh no! Webhook couldn't be sent :(")
+            thenewhook = await channel.create_webhook(name=webhookName, avatar=wimgdata)
+        except Exception as err:
+            logger.error(err)
+            await ctx.send("Could not create webhook. Please see bot logs for details...")
         else:
-            # Try adding react, if no perms then send normal message
-            try:
+            # Success
+            if ctx.channel.permissions_for(ctx.guild.me).add_reactions:
                 await ctx.message.add_reaction("✅")
-            except:
-                await ctx.send("Webhook updated ✅")
+            else:
+                await ctx.send("Done ✅")
+            await ctx.send(str(thenewhook.name)+" - ||"+str(thenewhook.url)+"||")
 
+    @sendhooktools.command()
+    @commands.has_permissions(manage_guild=True, manage_webhooks=True)
+    @commands.bot_has_permissions(manage_webhooks=True)
+    async def listhooks(self, ctx, channel: discord.TextChannel):
+        """List the webhooks in a channel (⚠️ Sensitive info)
 
-    @commands.command()
-    @checks.mod()
-    async def newhook(self, ctx, webhookName: str, webhookImage: str="", channel: discord.TextChannel=None):
-        """Create a webhook"""
-        if channel == None:
-            channel = ctx.message.channel
-        await ctx.message.add_reaction("⏳")
-        await ctx.send(str(channel.mention)+" "+str(channel.id))
-        async with aiohttp.ClientSession() as session:
-            async with session.get(webhookImage) as resp:
-                if resp.status != 200:
-                    return await channel.send('Could not download file...')
-                wimgdata = await resp.read()
-                try:
-                    thenewhook = await channel.create_webhook(name=webhookName, avatar=wimgdata)
-                except Exception as e:
-                    await ctx.send("Could not create webhook. Do I have permissions to create webhooks?\n"+str(e)+"\n"+str(wimgdata))
-                else:
-                    await ctx.message.add_reaction("✅")
-                    await ctx.send(str(thenewhook.name)+" "+str(thenewhook.url))
+        ⚠️ Webhook URLs are sensitive information. **Anyone can use them to send messages into your chat!** Please only run these commands in private guild channels.
+        """
 
-    
-    @commands.command()
-    @checks.mod()
-    async def listhooks(self, ctx, channel: discord.TextChannel=None):
-        """List the webhooks in a channel"""
-        if channel == None:
-            channel = ctx.message.channel
+        # 2025-03-14: Removing default channel, to force the help popup by default.
+        #     Not leaking webhook URLs by default
+
+        # if channel == None:
+        #     channel = ctx.message.channel
 
         a = await channel.webhooks()
+
+        # Exit if empty
+        if len(a) <= 0:
+            return await ctx.send("No webhooks found in this channel.")
+
         returntext = ""
 
-        if len(a) > 1:
-            for b in a:
-                name = str(b.name)
-                url = str(b.url)
-                returntext += name+"\n"+url+"\n\n"
-        else:
+        for b in a:
             name = str(b.name)
             url = str(b.url)
-            returntext += name+" "+url+"\n"
+            returntext += "- "+name+" - ||"+url+"||\n"
 
-        await ctx.send(returntext)
+        try:
+            await ctx.send(returntext[:1999])
+        except discord.HTTPException as err:
+            return await ctx.send(err)

--- a/sendhook/utils.py
+++ b/sendhook/utils.py
@@ -1,0 +1,103 @@
+import asyncio
+import json
+
+import discord
+from discord import Embed, Webhook
+import aiohttp
+
+import logging
+logger = logging.getLogger(__name__)
+
+
+# Utility Commands
+
+async def validateWebhookInput(self, ctx, userInput: str):
+    toWebhook = userInput
+    # Only check for alias if command is run in a guild
+    # 2025-03-15: Doesn't work in DMs, asks for "Manage Webhooks" permissions
+    if ctx.guild:
+        # Check if it is an alias
+        webhookAlias = await self.config.guild(ctx.guild).webhookAlias()
+        if userInput in webhookAlias:
+            toWebhook = webhookAlias.get(userInput, None)
+    if "https://" not in toWebhook:
+        raise commands.UserInputError("Error: Invalid webhook URL")
+    else:
+        return toWebhook
+
+
+# Engines
+
+async def sendhookEngine(toWebhook, content=None, attachments=None, embeds=None, webhookUser=None, webhookAvatar=None):
+    # Start webhook session
+    try:
+        async with aiohttp.ClientSession() as session:
+            webhook = Webhook.from_url(toWebhook, session=session)
+
+            # Check for attachments
+            if attachments:
+                # Send message first if there is a message
+                # 2025-03-15: AttributeError: 'dict' object has no attribute 'to_dict'
+                if content is not None:
+                    await webhook.send(
+                        content,
+                        embeds=([discord.Embed.from_dict(e) for e in embeds] if embeds else []),
+                        username=webhookUser,
+                        avatar_url=webhookAvatar
+                    )
+                # Then send each attachment in separate messages
+                for msgAttach in attachments:
+                    try:
+                        await webhook.send(
+                            username=webhookUser,
+                            avatar_url=webhookAvatar,
+                            file=await msgAttach.to_file()
+                        )
+                    except Exception:
+                        # Couldn't send, retry sending file as url only
+                        await webhook.send(
+                            "File: "+str(msgAttach.url), 
+                            username=webhookUser,
+                            avatar_url=webhookAvatar
+                        )
+            else:
+                # 2025-03-15: AttributeError: 'dict' object has no attribute 'to_dict'
+                await webhook.send(
+                    content,
+                    embeds=([discord.Embed.from_dict(e) for e in embeds] if embeds else []),
+                    username=webhookUser,
+                    avatar_url=webhookAvatar
+                )
+    except Exception as err:
+        logger.error(err, exc_info=True)
+        raise err
+    finally:
+        await session.close()
+
+
+async def edithookEngine(toWebhook, messageIdToEdit, content=None, attachments=None, embeds=None):
+    # Start webhook session
+    async with aiohttp.ClientSession() as session:
+        try:
+            webhook = Webhook.from_url(toWebhook, session=session)
+            messageAttributes = {
+                "message_id": messageIdToEdit,
+                "content": content,
+                "attachments": attachments,
+            }
+            # 2025-03-15: Support deleting the embeds by sending []
+            if embeds:
+                # AttributeError: 'dict' object has no attribute 'to_dict'
+                messageAttributes["embeds"] = [discord.Embed.from_dict(e) for e in embeds]
+            # "if embeds" returns False for []
+            elif embeds == []:
+                messageAttributes["embeds"] = []
+            else:
+                messageAttributes["embeds"] = None
+            # Remove Nones before sending
+            await webhook.edit_message(**{key: value for key, value in messageAttributes.items() if value is not None})
+        except Exception as err:
+            logger.error(err, exc_info=True)
+            raise err
+        finally:
+            await session.close()

--- a/sendhook/utils.py
+++ b/sendhook/utils.py
@@ -11,6 +11,19 @@ logger = logging.getLogger(__name__)
 
 # Utility Commands
 
+async def friendlyReact(ctx, react: str="✅", react_str: str="Done ✅"):
+    try:
+        return await ctx.message.add_reaction(react)
+    except Exception:
+        # discord.Forbidden - Missing add_reactions permission, send as plaintext message
+        # discord.HybridCommandError - Slash command ctx message issue, just send as new message
+        # discord.HTTPException - Original message deleted
+        if react_str is not None:
+            return await ctx.send(react_str)
+        else:
+            pass
+
+
 async def validateWebhookInput(self, ctx, userInput: str):
     toWebhook = userInput
     # Only check for alias if command is run in a guild


### PR DESCRIPTION
#45

SendHook

- [x]     :memo: Some commands do not check if the bot has add_reactions permissions where needed.
- [x]     :memo: The cog does not check if the bot has manage_webhooks permissions where needed.
- [x]     :memo: [p]aliashook show errors if the alias has not been configured yet:
   ```
    Traceback (most recent call last):
      File "datapath\cogs\CogManager\cogs\sendhook\sendhook.py", line 115, in ahshow
        webhookData = webhookAlias[alias]
    KeyError: 'example'
   ```
- [x]     Consider using [SyncWebhook.edit_message](https://discordpy.readthedocs.io/en/latest/api.html#discord.SyncWebhook.edit_message) instead of a manual API request.
   -  **Response:**
    Resolved, migrated to Webhook.edit_message (async)
- [x]     You should either swap the permission requirement to manage_webhooks or use mod_or_permissions with that permission. This will allow for more seamless access.
- [x]     The help texts for the commands in this cog are not very verbose, and many commands have basic text inputs with special requirements that are not explained (ie links to images).
- [x]     :memo: [p]sendhook listhooks doesn’t handle a channel with < 2 webhooks nicely.
   ```
    Traceback (most recent call last):
      File "datapath\cogs\CogManager\cogs\sendhook\sendhook.py", line 251, in listhooks
        name = str(b.name)
    UnboundLocalError: local variable 'b' referenced before assignment
   ```
- [x]     It probably makes more sense to automatically alias a webhook to its title, rather than sending the URL.
  - **Response:**
  Only manually added aliases are stored currently. This cog focuses on allowing sending to all of the following: channel webhooks, guild webhooks, external guild webhooks, and external Discord-webhook-format compatible webhooks. Because of this, it is difficult to fetch webhook guild/channel/title info from `Webhook.from_url()`, or assume anything about guild/channel from setup. This may change in the future, but would need a `WebhookAlias` data schema update for adding a notes section per alias/webhook.
   
  - Webhook URLs are technically privileged information, so this would make it less likely to accidentally leak one, and make the UX neater.
  - **Response:**
  Security prompts have been added noting that webhook URLs are sensitive information, and that the commands should only be sent in private channels.
        
General

- [see #45]     Consider using TitleCase instead of Titlecase casing for your class names to maintain consistency with how users expect to get [p]help for 3rd party cogs.
- [x]     :memo: Several of your cogs use requests (or urllib.requests), which is a [blocking](https://discordpy.readthedocs.io/en/latest/faq.html#what-does-blocking-mean) way to make HTTP requests. You should instead use aiohttp (as several of your cogs do) to make HTTP requests in an asynchronous way.
- [x]     :memo: Some cogs have requests in their requirements, despite it not being used.
- [x]     Some cogs have aiohttp and asyncio in their requirements. Those libraries are already requirements of Red, so listing them is not necessary.
- [see #45]     Despite some cogs including it, permissions is not a valid info.json key, and including it will not resolve the need to add proper permissions checking to commands.
- [x]     You have bare except blocks in a few places. Consider at least replacing them with except Exception, to avoid catching standard control errors like the one generated by CTRL+Cing. Ideally, identify the error you actually intend to catch and use that instead (generally discord.HTTPException is a good bet for Discord API calls).
- [x]     Consider checking the response.status in your aiohttp requests in case the URL requested goes offline or has an error.
