### PR TITLE
Red Cog Approval: zidian

### DIFF
--- a/zidian/info.json
+++ b/zidian/info.json
@@ -3,7 +3,7 @@
   "install_msg" : "**Note: Please run  `[p]load zidian`  then  `[p]setzidian update`  to fetch the dictionary on first install.**\nTo use the dictionary, use  **`[p]zidian`**\n---\n\nThanks for installing, I hope you enjoy :) To stay up to date with breaking changes, you might want to join my Support Discord. To find documentation, Discord, and more, drop by the website at <https://coffeebank.github.io/coffee-cogs/zidian>",
   "name" : "zidian",
   "short" : "Chinese dictionary bot",
-  "requirements" : ["asyncio", "aiohttp"],
+  "requirements" : [],
   "description" : "Chinese dictionary bot. Can search Chinese characters, Pinyin, and English. Fetches results locally from saved dictionaries. Uses CC-CEDICT.\n\nInspired by Pleco and Jisho.",
   "permissions" : [],
   "end_user_data_statement" : "This cog does not store any End User Data.",

--- a/zidian/zidian.py
+++ b/zidian/zidian.py
@@ -47,6 +47,18 @@ class Zidian(commands.Cog):
 
     ## Utility commands
 
+    async def friendlyReact(ctx, react: str="✅", react_str: str="Done ✅"):
+        try:
+            return await ctx.message.add_reaction(react)
+        except Exception:
+            # discord.Forbidden - Missing add_reactions permission, send as plaintext message
+            # discord.HybridCommandError - Slash command ctx message issue, just send as new message
+            # discord.HTTPException - Original message deleted
+            if react_str is not None:
+                return await ctx.send(react_str)
+            else:
+                pass
+
     def search_file(self, filename, pattern):
         regex = re.compile(pattern, re.IGNORECASE)
         with open(filename, encoding="utf-8") as file:
@@ -101,7 +113,7 @@ class Zidian(commands.Cog):
                     cedictHeaders = self.search_file(text_extracted, r"^\#[\!]?\s.*")
                     await self.config.dictHeaders.cedict.set(cedictHeaders)
 
-        await ctx.message.add_reaction("✅")
+        await friendlyReact(ctx, "✅", "Done ✅")
 
     @commands.command(name="zidian")
     async def zidian(self, ctx, *, keyword):

--- a/zidian/zidian.py
+++ b/zidian/zidian.py
@@ -129,8 +129,12 @@ class Zidian(commands.Cog):
         English - Note: may not work well
 
         Note: CC-CEDICT does not contain use frequency, so some results may not be great.
-        Settings: **`[p]setzidian`**"""
+        Settings: **`[p]setzidian`**
+        """
         dictCedict = await self.config.dictStorage.cedict()
+
+
+        assert dictCedict is not None
         
         patternKeyword = re.escape(keyword).replace(" ", r"s{0}(\s|\d\s)")
         startText = fr'(^{patternKeyword}|^[^\[]+\s{patternKeyword}|^[^\[]+\[{patternKeyword}(\d\]|\]).*|^[^\/]+\/{patternKeyword}([^=a-zA-Z]+).*)'
@@ -151,12 +155,12 @@ class Zidian(commands.Cog):
 
         if matches is not None:
             for index, i in enumerate(matches):
-            if index == 6:
-                break
-            entry = i.split("/", 1)
-            try:
-                sendEmbed.add_field(name=entry[0], value=entry[1][:-1][:1100], inline=True)
-            except:
-                pass
+                if index == 6:
+                    break
+                entry = i.split("/", 1)
+                try:
+                    sendEmbed.add_field(name=entry[0], value=entry[1][:-1][:1100], inline=True)
+                except:
+                    pass
 
         await ctx.send(embed=sendEmbed)

--- a/zidian/zidian.py
+++ b/zidian/zidian.py
@@ -1,11 +1,15 @@
-# from redbot.core import Config
-from redbot.core import Config, commands, checks
 import asyncio
-import aiohttp
-import discord
 import io
 import re
 import zipfile
+
+from redbot.core import Config, commands
+import discord
+import aiohttp
+
+import logging
+logger = logging.getLogger(__name__)
+
 
 class Zidian(commands.Cog):
     """Chinese dictionary bot
@@ -66,7 +70,7 @@ class Zidian(commands.Cog):
           pass
 
     @setzidian.command(name="list", aliases=["dict", "dictionaries"])
-    @checks.is_owner()
+    @commands.is_owner()
     async def dictionaries(self, ctx):
         """List dictionaries"""
         srcHeaders = await self.config.dictHeaders()
@@ -78,7 +82,7 @@ class Zidian(commands.Cog):
           await ctx.send("No dictionaries. Please run update command to initialize the dictionaries.")
 
     @setzidian.command(name="update")
-    @checks.is_owner()
+    @commands.is_owner()
     async def update(self, ctx):
         """Update dictionaries"""
 

--- a/zidian/zidian.py
+++ b/zidian/zidian.py
@@ -84,6 +84,7 @@ class Zidian(commands.Cog):
 
     @setzidian.command(name="list", aliases=["dict", "dictionaries"])
     @commands.is_owner()
+    @commands.bot_has_permissions(embed_links=True)
     async def dictionaries(self, ctx):
         """List dictionaries"""
         srcHeaders = await self.config.dictHeaders()

--- a/zidian/zidian.py
+++ b/zidian/zidian.py
@@ -24,12 +24,12 @@ class Zidian(commands.Cog):
 
         # Bot owner configs
         default_global = {
-          "dictHeaders": {
-            "cedict": None,
-          },
-          "dictStorage": {
-            "cedict": None,
-          }
+            "dictHeaders": {
+                "cedict": None,
+            },
+            "dictStorage": {
+                "cedict": None,
+            }
         }
         self.config.register_global(**default_global)
 
@@ -48,15 +48,15 @@ class Zidian(commands.Cog):
     ## Utility commands
 
     def search_file(self, filename, pattern):
-      regex = re.compile(pattern, re.IGNORECASE)
-      with open(filename, encoding="utf-8") as file:
-          return [line.strip() for line in file if regex.search(line)]
+        regex = re.compile(pattern, re.IGNORECASE)
+        with open(filename, encoding="utf-8") as file:
+            return [line.strip() for line in file if regex.search(line)]
 
     def stringize(self, arr):
-      msg = ""
-      for i in arr:
-        msg += str(i) + "\n"
-      return msg
+        msg = ""
+        for i in arr:
+            msg += str(i) + "\n"
+        return msg
 
     
     ## Bot commands
@@ -67,7 +67,7 @@ class Zidian(commands.Cog):
         
         Please run update command to initialize the dictionaries."""
         if not ctx.invoked_subcommand:
-          pass
+            pass
 
     @setzidian.command(name="list", aliases=["dict", "dictionaries"])
     @commands.is_owner()
@@ -75,11 +75,11 @@ class Zidian(commands.Cog):
         """List dictionaries"""
         srcHeaders = await self.config.dictHeaders()
         try:
-          for i in srcHeaders:
-            e = discord.Embed(color=(await ctx.embed_colour()), title=i, description=self.stringize(srcHeaders[i]))
-            await ctx.send(embed=e)
+            for i in srcHeaders:
+                e = discord.Embed(color=(await ctx.embed_colour()), title=i, description=self.stringize(srcHeaders[i]))
+                await ctx.send(embed=e)
         except:
-          await ctx.send("No dictionaries. Please run update command to initialize the dictionaries.")
+            await ctx.send("No dictionaries. Please run update command to initialize the dictionaries.")
 
     @setzidian.command(name="update")
     @commands.is_owner()
@@ -90,61 +90,61 @@ class Zidian(commands.Cog):
         await self.config.dictStorage.cedict.set(None)
         url = "https://www.mdbg.net/chinese/export/cedict/cedict_1_0_ts_utf-8_mdbg.zip"
         async with aiohttp.ClientSession() as session:
-          async with session.get(url) as response:
-            content = await response.read()
-            with zipfile.ZipFile(io.BytesIO(content)) as zip_file:
-                # Extract the first file in the zip (assumed to be the text file)
-                text_filename = zip_file.namelist()[0]
-                text_extracted = zip_file.extract(text_filename)
-                await self.config.dictStorage.cedict.set(text_extracted)
-                # Add source headers
-                cedictHeaders = self.search_file(text_extracted, r"^\#[\!]?\s.*")
-                await self.config.dictHeaders.cedict.set(cedictHeaders)
+            async with session.get(url) as response:
+                content = await response.read()
+                with zipfile.ZipFile(io.BytesIO(content)) as zip_file:
+                    # Extract the first file in the zip (assumed to be the text file)
+                    text_filename = zip_file.namelist()[0]
+                    text_extracted = zip_file.extract(text_filename)
+                    await self.config.dictStorage.cedict.set(text_extracted)
+                    # Add source headers
+                    cedictHeaders = self.search_file(text_extracted, r"^\#[\!]?\s.*")
+                    await self.config.dictHeaders.cedict.set(cedictHeaders)
 
         await ctx.message.add_reaction("✅")
 
     @commands.command(name="zidian")
     async def zidian(self, ctx, *, keyword):
-      """Search the zidian 字典
+        """Search the zidian 字典
 
-      `咖啡`
-      Chinese characters
-      
-      `ka fei` / `ka1 fei1`
-      Pinyin - put spaces in between, tones optional, ü -> u:
+        `咖啡`
+        Chinese characters
+        
+        `ka fei` / `ka1 fei1`
+        Pinyin - put spaces in between, tones optional, ü -> u:
 
-      `coffee`
-      English - Note: may not work well
+        `coffee`
+        English - Note: may not work well
 
-      Note: CC-CEDICT does not contain use frequency, so some results may not be great.
-      Settings: **`[p]setzidian`**"""
-      dictCedict = await self.config.dictStorage.cedict()
-      
-      patternKeyword = re.escape(keyword).replace(" ", r"s{0}(\s|\d\s)")
-      startText = fr'(^{patternKeyword}|^[^\[]+\s{patternKeyword}|^[^\[]+\[{patternKeyword}(\d\]|\]).*|^[^\/]+\/{patternKeyword}([^=a-zA-Z]+).*)'
-      middleText = fr'(^.*{patternKeyword}.*)'
-      matches = None
+        Note: CC-CEDICT does not contain use frequency, so some results may not be great.
+        Settings: **`[p]setzidian`**"""
+        dictCedict = await self.config.dictStorage.cedict()
+        
+        patternKeyword = re.escape(keyword).replace(" ", r"s{0}(\s|\d\s)")
+        startText = fr'(^{patternKeyword}|^[^\[]+\s{patternKeyword}|^[^\[]+\[{patternKeyword}(\d\]|\]).*|^[^\/]+\/{patternKeyword}([^=a-zA-Z]+).*)'
+        middleText = fr'(^.*{patternKeyword}.*)'
+        matches = None
 
-      try:
-        with open(dictCedict, encoding="utf-8") as file:
-          matches = self.search_file(dictCedict, startText)
-          sendEmbed = discord.Embed(color=(await ctx.embed_colour()), title="Results")
-      except FileNotFoundError as err:
-        return await ctx.send("Dictionary not initialized! Please run  **`[p]setzidian update`**  to initialize the dictionary first....")
+        try:
+            with open(dictCedict, encoding="utf-8") as file:
+                matches = self.search_file(dictCedict, startText)
+                sendEmbed = discord.Embed(color=(await ctx.embed_colour()), title="Results")
+        except FileNotFoundError as err:
+            return await ctx.send("Dictionary not initialized! Please run  **`[p]setzidian update`**  to initialize the dictionary first....")
 
-      if len(matches) < 1:
-        with open(dictCedict, encoding="utf-8") as file:
-          matches = self.search_file(dictCedict, middleText)
-          sendEmbed = discord.Embed(color=(await ctx.embed_colour()), title="Results (Extended)")
+        if len(matches) < 1:
+            with open(dictCedict, encoding="utf-8") as file:
+                matches = self.search_file(dictCedict, middleText)
+                sendEmbed = discord.Embed(color=(await ctx.embed_colour()), title="Results (Extended)")
 
-      if matches is not None:
-        for index, i in enumerate(matches):
-          if index == 6:
-            break
-          entry = i.split("/", 1)
-          try:
-            sendEmbed.add_field(name=entry[0], value=entry[1][:-1][:1100], inline=True)
-          except:
-            pass
+        if matches is not None:
+            for index, i in enumerate(matches):
+            if index == 6:
+                break
+            entry = i.split("/", 1)
+            try:
+                sendEmbed.add_field(name=entry[0], value=entry[1][:-1][:1100], inline=True)
+            except:
+                pass
 
-      await ctx.send(embed=sendEmbed)
+        await ctx.send(embed=sendEmbed)

--- a/zidian/zidian.py
+++ b/zidian/zidian.py
@@ -110,6 +110,15 @@ class Zidian(commands.Cog):
         try:
             async with aiohttp.ClientSession() as session:
                 async with session.get(url) as response:
+                    if response.status != 200:
+                        err = aiohttp.ClientResponseError(
+                            response.request_info,
+                            response.history,
+                            status=response.status,
+                            message=response.reason
+                        )
+                        logger.error(f"Failed to fetch: {str(err)}")
+                        raise err
                     content = await response.read()
                     with zipfile.ZipFile(io.BytesIO(content)) as zip_file:
                         # Extract the first file in the zip (assumed to be the text file)

--- a/zidian/zidian.py
+++ b/zidian/zidian.py
@@ -88,10 +88,11 @@ class Zidian(commands.Cog):
         srcHeaders = await self.config.dictHeaders()
         try:
             for i in srcHeaders:
-                e = discord.Embed(color=(await ctx.embed_colour()), title=i, description=self.stringize(srcHeaders[i]))
+                e = discord.Embed(color=(await ctx.embed_colour()), title=i, description=self.stringize(srcHeaders[i]).replace("#", ".")[:4096])
                 await ctx.send(embed=e)
-        except:
-            await ctx.send("No dictionaries. Please run update command to initialize the dictionaries.")
+        except Exception as err:
+            logger.error(err, exc_info=True)
+            return await ctx.send("No dictionaries. Please run update command to initialize the dictionaries.")
 
     @setzidian.command(name="update")
     @commands.is_owner()

--- a/zidian/zidian.py
+++ b/zidian/zidian.py
@@ -78,7 +78,7 @@ class Zidian(commands.Cog):
     
     ## Bot commands
 
-    @commands.group(aliases=["setzd"])
+    @commands.hybrid_group(aliases=["setzd"])
     async def setzidian(self, ctx: commands.Context):
         """Zidian cog settings
         
@@ -157,7 +157,7 @@ class Zidian(commands.Cog):
             await session.close()
 
 
-    @commands.command(name="zidian")
+    @commands.hybrid_command(name="zidian")
     @commands.bot_has_permissions(embed_links=True)
     async def zidian(self, ctx, *, keyword):
         """Search the zidian 字典


### PR DESCRIPTION
#45

Zidian

- [x]     The #s to denote comments cause the [p]setzidian headers output to use h1 formatting and be very big. Consider stripping the leading # for readability.
- [x]     :memo: [p]zidian does not check if the bot has embed_links permissions.
- [x]     :memo: [p]zidian update does not check if the bot has add_reactions permissions.
- [x]     :memo: You should not be extracting the zip file without specifying the path to extract to as a path within [cog_data_path](https://docs.discord.red/en/stable/framework_datamanager.html#redbot.core.data_manager.cog_data_path).
  - It is unclear if this is an actual API, or a statically hosted file that should never change. If it isn’t expected to change, consider bundling it and using bundled_data_path instead.
  - **Response:**
  The URL stays the same, but the contents update regularly (see [mdbg.net](https://www.mdbg.net/chinese/dictionary?page=cc-cedict), "Last Updated"). As such, `zidian` has added an update command to fetch the latest version.

General

- [see #45]     Consider using TitleCase instead of Titlecase casing for your class names to maintain consistency with how users expect to get [p]help for 3rd party cogs.
- [x]     Some cogs have aiohttp and asyncio in their requirements. Those libraries are already requirements of Red, so listing them is not necessary.
- [x]     You have bare except blocks in a few places. Consider at least replacing them with except Exception, to avoid catching standard control errors like the one generated by CTRL+Cing. Ideally, identify the error you actually intend to catch and use that instead (generally discord.HTTPException is a good bet for Discord API calls).
- [x]     Consider checking the response.status in your aiohttp requests in case the URL requested goes offline or has an error.